### PR TITLE
Reorder commands and introduce tag manage command

### DIFF
--- a/internal/commands/cmd.go
+++ b/internal/commands/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/hub-cli-plugin/internal"
+	"github.com/docker/hub-cli-plugin/internal/commands/tag"
 )
 
 type options struct {
@@ -34,9 +35,9 @@ type options struct {
 func NewHubCmd(ctx context.Context, dockerCli command.Cli) *cobra.Command {
 	var flags options
 	cmd := &cobra.Command{
+		Use:         "hub",
 		Short:       "Docker Hub",
 		Long:        `A tool to manage your Docker Hub images`,
-		Use:         "hub",
 		Annotations: map[string]string{},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if flags.showVersion {
@@ -47,10 +48,7 @@ func NewHubCmd(ctx context.Context, dockerCli command.Cli) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&flags.showVersion, "version", false, "Display version of the scan plugin")
 
-	cmd.AddCommand(
-		newListCmd(ctx, dockerCli),
-		newRmiCmd(ctx, dockerCli),
-	)
+	cmd.AddCommand(tag.NewTagCmd(ctx, dockerCli))
 	return cmd
 }
 

--- a/internal/commands/tag/cmd.go
+++ b/internal/commands/tag/cmd.go
@@ -1,0 +1,40 @@
+/*
+   Copyright 2020 Docker Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tag
+
+import (
+	"context"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+//NewTagCmd configures the tag manage command
+func NewTagCmd(ctx context.Context, dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "tag",
+		Long: "Manage tags",
+		Args: cli.NoArgs,
+		RunE: command.ShowHelp(dockerCli.Err()),
+	}
+	cmd.AddCommand(
+		newListCmd(ctx, dockerCli),
+		newRmCmd(ctx, dockerCli),
+	)
+	return cmd
+}

--- a/internal/commands/tag/list.go
+++ b/internal/commands/tag/list.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package commands
+package tag
 
 import (
 	"context"

--- a/internal/commands/tag/rmi.go
+++ b/internal/commands/tag/rmi.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package commands
+package tag
 
 import (
 	"bufio"
@@ -37,21 +37,21 @@ type rmiOptions struct {
 	force bool
 }
 
-func newRmiCmd(ctx context.Context, dockerCli command.Cli) *cobra.Command {
+func newRmCmd(ctx context.Context, dockerCli command.Cli) *cobra.Command {
 	var opts rmiOptions
 	cmd := &cobra.Command{
-		Use:   "rmi REPOSITORY:TAG",
+		Use:   "rm REPOSITORY:TAG",
 		Short: "Delete a tag in a repository",
 		Args:  cli.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runRmi(ctx, dockerCli, opts, args[0])
+			return runRm(ctx, dockerCli, opts, args[0])
 		},
 	}
 	cmd.Flags().BoolVar(&opts.force, "platforms", false, "List all available platforms per tag")
 	return cmd
 }
 
-func runRmi(ctx context.Context, dockerCli command.Cli, opts rmiOptions, image string) error {
+func runRm(ctx context.Context, dockerCli command.Cli, opts rmiOptions, image string) error {
 	ref, err := reference.Parse(image)
 	if err != nil {
 		return err


### PR DESCRIPTION
Now commands are:
```sh
$ docker hub tag ls REPO
$ docker hub tag rm REPO:TAG
```
