### PR TITLE
Use the new status fields in the tag api

### DIFF
--- a/internal/commands/tag/list.go
+++ b/internal/commands/tag/list.go
@@ -43,6 +43,18 @@ var (
 			}
 			return ""
 		}},
+		{"STATUS", func(t hub.Tag) string {
+			if len(t.Images) > 0 {
+				return t.Images[0].Status // TODO: status should be on the tag/manifest list level too, not only on the image level
+			}
+			return ""
+		}},
+		{"EXPIRES", func(t hub.Tag) string {
+			if len(t.Images) > 0 && t.Images[0].Expires.Nanosecond() != 0 {
+				return units.HumanDuration(time.Until(t.Images[0].Expires))
+			}
+			return ""
+		}},
 		{"LAST UPDATE", func(t hub.Tag) string {
 			if t.LastUpdated.Nanosecond() == 0 {
 				return ""

--- a/internal/hub/tags.go
+++ b/internal/hub/tags.go
@@ -49,6 +49,10 @@ type Image struct {
 	Os           string
 	Variant      string
 	Size         int
+	Expires      time.Time
+	LastPulled   time.Time
+	LastPushed   time.Time
+	Status       string
 }
 
 //GetTags calls the hub repo API and returns all the information on all tags
@@ -152,6 +156,11 @@ type hubTagImage struct {
 	OsFeatures   string `json:"os_features,omitempty"`
 	OsVersion    string `json:"os_version,omitempty"`
 	Size         int    `json:"size"`
+	// New API
+	Expires    time.Time `json:"expires,omitempty"`
+	LastPulled time.Time `json:"last_pulled,omitempty"`
+	LastPushed time.Time `json:"last_pushed,omitempty"`
+	Status     string    `json:"status,omitempty"`
 }
 
 func getRepoPath(s string) (string, error) {
@@ -173,6 +182,10 @@ func toImages(result []hubTagImage) []Image {
 			Os:           result[i].Os,
 			Variant:      result[i].Variant,
 			Size:         result[i].Size,
+			Status:       result[i].Status,
+			Expires:      result[i].Expires,
+			LastPulled:   result[i].LastPulled,
+			LastPushed:   result[i].LastPushed,
 		}
 	}
 	return images


### PR DESCRIPTION
**- What I did**
Added the new status and expire column:
```sh
$ DOCKER_SCAN_HUB_INSTANCE=staging docker hub tag ls silvin/toto
TAG                 DIGEST                                                                    STATUS              EXPIRES             LAST UPDATE         SIZE
vuln                sha256:1e8b199249d6d0ef3419ddc6eda2348d9fbdb10d350d3bb70aa98e87faa227c9   active              5 months            4 weeks ago         60.18MB
vuln2               sha256:a44ab0cca6cd9411032d180bc396f19bc98f71972d2398d50460145cab81c5ab   active              5 months            4 weeks ago         50.4MB
```