### PR TITLE
Added last push and last pulled columns.

### DIFF
--- a/internal/commands/tag/list.go
+++ b/internal/commands/tag/list.go
@@ -61,6 +61,18 @@ var (
 			}
 			return fmt.Sprintf("%s ago", units.HumanDuration(time.Since(t.LastUpdated)))
 		}},
+		{"LAST PUSHED", func(t hub.Tag) string {
+			if len(t.Images) > 0 && t.Images[0].LastPushed.Nanosecond() != 0 {
+				return units.HumanDuration(time.Since(t.Images[0].LastPushed))
+			}
+			return ""
+		}},
+		{"LAST PULLED", func(t hub.Tag) string {
+			if len(t.Images) > 0 && t.Images[0].LastPulled.Nanosecond() != 0 {
+				return units.HumanDuration(time.Since(t.Images[0].LastPulled))
+			}
+			return ""
+		}},
 		{"SIZE", func(t hub.Tag) string {
 			size := t.FullSize
 			if len(t.Images) > 0 {


### PR DESCRIPTION
Those values are only available on hub staging.
So one must login using: 
```sh
$ docker login index-stage.docker.io -u <username-on-staging>
```
Then set this env var: `DOCKER_SCAN_HUB_INSTANCE=staging`
```sh
$ DOCKER_SCAN_HUB_INSTANCE=staging docker hub tag ls silvin/testrmi --platforms
TAG                 DIGEST                                                                    STATUS              EXPIRES             LAST UPDATE         LAST PUSHED         LAST PULLED         SIZE                OS/ARCH
nginx               sha256:8ff4598873f588ca9d2bf1be51bdb117ec8f56cdfd5a81b5bb0224a61565aa49   active              5 months            5 minutes ago       3 weeks             3 weeks             53.44MB             linux/amd64
v1                  sha256:fd4a8673d0344c3a7f427fe4440d4b8dfd4fa59cfabbd9098f9eb0cb4ba905d0   expired                                 17 minutes ago                                              760.5kB             linux/amd64
```