### PR TITLE
`make help` should show the targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,4 +84,4 @@ validate: validate-go-mod validate-headers ## Validate sources
 .PHONY: help
 help: ## Show help
 	@echo Please specify a build target. The choices are:
-	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":| ## "}; {printf "\033[36m%-30s\033[0m %s\n", $$2, $$NF}'


### PR DESCRIPTION
Before:

```
$ make help
Please specify a build target. The choices are:
Makefile                       Build the tool in a container
Makefile                       Cross compile the tool binaries in a container
Makefile                       Install the tool to your /usr/local/bin/
Makefile                       Run the end-to-end tests
Makefile                       Run unit tests
Makefile                       Run the go linter
Makefile                       Validate files license header
Makefile                       Validate go.mod and go.sum are up-to-date
Makefile                       Validate sources
Makefile                       Show help
```

After:

```
$ make help
Please specify a build target. The choices are:
build                          Build the tool in a container
cross                          Cross compile the tool binaries in a container
install                        Install the tool to your /usr/local/bin/
e2e                            Run the end-to-end tests
test-unit                      Run unit tests
lint                           Run the go linter
validate-headers               Validate files license header
validate-go-mod                Validate go.mod and go.sum are up-to-date
validate                       Validate sources
help                           Show help
```

