### PR TITLE
Add a new account info command

### DIFF
--- a/internal/commands/account/cmd.go
+++ b/internal/commands/account/cmd.go
@@ -1,0 +1,43 @@
+/*
+   Copyright 2020 Docker Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package account
+
+import (
+	"context"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+const (
+	accountName = "account"
+)
+
+//NewAccountCmd configures the org manage command
+func NewAccountCmd(ctx context.Context, dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  accountName,
+		Long: "Manage organizations",
+		Args: cli.NoArgs,
+		RunE: command.ShowHelp(dockerCli.Err()),
+	}
+	cmd.AddCommand(
+		newInfoCmd(ctx, dockerCli, accountName),
+	)
+	return cmd
+}

--- a/internal/commands/account/info.go
+++ b/internal/commands/account/info.go
@@ -1,0 +1,124 @@
+/*
+   Copyright 2020 Docker Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package account
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/cli/cli/utils"
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/registry"
+	"github.com/docker/go-units"
+	"github.com/spf13/cobra"
+
+	"github.com/docker/hub-cli-plugin/internal/format"
+	"github.com/docker/hub-cli-plugin/internal/hub"
+	"github.com/docker/hub-cli-plugin/internal/metrics"
+)
+
+const (
+	infoName = "info"
+)
+
+type infoOptions struct {
+	format.Option
+}
+
+func newInfoCmd(ctx context.Context, dockerCli command.Cli, parent string) *cobra.Command {
+	var opts infoOptions
+	cmd := &cobra.Command{
+		Use:   infoName + " [OPTIONS]",
+		Short: "Print the account information",
+		Args:  cli.NoArgs,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			metrics.Send(parent, infoName)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInfo(ctx, dockerCli, opts)
+		},
+	}
+	opts.AddFormatFlag(cmd.Flags())
+	cmd.Flags().SetInterspersed(false)
+	return cmd
+}
+
+func runInfo(ctx context.Context, dockerCli command.Cli, opts infoOptions) error {
+	authResolver := func(hub *registry.IndexInfo) types.AuthConfig {
+		return command.ResolveAuthConfig(ctx, dockerCli, hub)
+	}
+	client, err := hub.NewClient(authResolver)
+	if err != nil {
+		return err
+	}
+	user, err := client.GetUserInfo()
+	if err != nil {
+		return err
+	}
+	plan, err := client.GetHubPlan(user.ID)
+	if err != nil {
+		return err
+	}
+	return opts.Print(os.Stdout, account{user, plan}, printAccount)
+}
+
+func printAccount(out io.Writer, value interface{}) error {
+	account := value.(account)
+	// print user info
+	w := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
+	fmt.Fprintf(w, utils.Blue("Username:")+"\t%s\n", account.User.UserName)
+	fmt.Fprintf(w, utils.Blue("Full name:")+"\t%s\n", account.User.FullName)
+	fmt.Fprintf(w, utils.Blue("Company:")+"\t%s\n", account.User.Company)
+	fmt.Fprintf(w, utils.Blue("Location:")+"\t%s\n", account.User.Location)
+	fmt.Fprintf(w, utils.Blue("Joined:")+"\t%s ago\n", units.HumanDuration(time.Since(account.User.Joined)))
+	fmt.Fprintf(w, utils.Blue("Plan:")+"\t%s\n", utils.Green(account.Plan.Name))
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	// print plan info
+	w = tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
+	fmt.Fprintf(w, utils.Blue("Limits:")+"\n")
+	fmt.Fprintf(w, utils.Blue("%sSeats:")+"\t%v\n", pfx, account.Plan.Limits.Seats)
+	fmt.Fprintf(w, utils.Blue("%sPrivate repositories:")+"\t%v\n", pfx, account.Plan.Limits.PrivateRepos)
+	fmt.Fprintf(w, utils.Blue("%sParallel builds:")+"\t%v\n", pfx, account.Plan.Limits.ParallelBuilds)
+	fmt.Fprintf(w, utils.Blue("%sCollaborators:")+"\t%v\n", pfx, getLimit(account.Plan.Limits.Collaborators))
+	fmt.Fprintf(w, utils.Blue("%sTeams:")+"\t%v\n", pfx, getLimit(account.Plan.Limits.Teams))
+	return w.Flush()
+}
+
+func getLimit(number int) string {
+	if number == 9999 {
+		return utils.Green("unlimited")
+	}
+	return fmt.Sprintf("%v", number)
+}
+
+const (
+	pfx = "  "
+)
+
+type account struct {
+	User *hub.User
+	Plan *hub.Plan
+}

--- a/internal/commands/account/info_test.go
+++ b/internal/commands/account/info_test.go
@@ -1,0 +1,55 @@
+/*
+   Copyright 2020 Docker Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package account
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"gotest.tools/golden"
+	"gotest.tools/v3/assert"
+
+	"github.com/docker/hub-cli-plugin/internal/hub"
+)
+
+func TestInfoOutput(t *testing.T) {
+	account := account{
+		User: &hub.User{
+			ID:       "id",
+			UserName: "my-user-name",
+			FullName: "My Full Name",
+			Location: "MyLocation",
+			Company:  "My Company",
+			Joined:   time.Now(),
+		},
+		Plan: &hub.Plan{
+			Name: "free",
+			Limits: hub.Limits{
+				Seats:          1,
+				PrivateRepos:   2,
+				Teams:          9999,
+				Collaborators:  9999,
+				ParallelBuilds: 3,
+			},
+		},
+	}
+	buf := bytes.NewBuffer(nil)
+	err := printAccount(buf, account)
+	assert.NilError(t, err)
+	golden.Assert(t, buf.String(), "info.golden")
+}

--- a/internal/commands/account/testdata/info.golden
+++ b/internal/commands/account/testdata/info.golden
@@ -1,0 +1,12 @@
+Username:  my-user-name
+Full name: My Full Name
+Company:   My Company
+Location:  MyLocation
+Joined:    Less than a second ago
+Plan:      free
+Limits:
+  Seats:                1
+  Private repositories: 2
+  Parallel builds:      3
+  Collaborators:        unlimited
+  Teams:                unlimited

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/hub-cli-plugin/internal"
+	"github.com/docker/hub-cli-plugin/internal/commands/account"
 	"github.com/docker/hub-cli-plugin/internal/commands/org"
 	"github.com/docker/hub-cli-plugin/internal/commands/repo"
 	"github.com/docker/hub-cli-plugin/internal/commands/tag"
@@ -51,6 +52,7 @@ func NewRootCmd(ctx context.Context, dockerCli command.Cli, name string) *cobra.
 	cmd.Flags().BoolVar(&flags.showVersion, "version", false, "Display version of the scan plugin")
 
 	cmd.AddCommand(
+		account.NewAccountCmd(ctx, dockerCli),
 		org.NewOrgCmd(ctx, dockerCli),
 		repo.NewRepoCmd(ctx, dockerCli),
 		tag.NewTagCmd(ctx, dockerCli),


### PR DESCRIPTION
It prints the current user information and the current hub plan.

```sh
$ hub-tool account info
Username:  username
Full name: Full name
Company:   Awesome corp
Location:  some location
Joined:    X years ago
Plan:      free
Limits:
  Seats:                1
  Private repositories: 1
  Parallel builds:      1
  Collaborators:        unlimited
  Teams:                unlimited
```