### PR TITLE
switch from using index.docker.io to registry.docker.io

### DIFF
--- a/internal/hub/instances.go
+++ b/internal/hub/instances.go
@@ -46,7 +46,7 @@ var (
 	staging = Instance{
 		APIHubBaseURL: "https://hub-stage.docker.com",
 		RegistryInfo: &registry.IndexInfo{
-			Name:     "index-stage.docker.io",
+			Name:     "registry-stage.docker.io",
 			Mirrors:  nil,
 			Secure:   true,
 			Official: false,
@@ -56,7 +56,7 @@ var (
 	prod = Instance{
 		APIHubBaseURL: "https://hub.docker.com",
 		RegistryInfo: &registry.IndexInfo{
-			Name:     "index.docker.io",
+			Name:     "registry.docker.io",
 			Mirrors:  nil,
 			Secure:   true,
 			Official: true,


### PR DESCRIPTION
Signed-off-by: Alex Hokanson <571756+ingshtrom@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/hub-cli-plugin/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I changed the references to urls of Hub registry to `registry.docker.io` because
that is the _blessed_ URL to use. `index.docker.io` should not be used.

**- How I did it**
With neovim :shrug:

**- How to verify it**
I guess you could run a packet sniffer or something, but I just kind of assumed
since I searched the codebase for `index` and didn't find anything else.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/571756/95508411-76f43580-09a2-11eb-8ca1-f10dfafc5194.png)

