### PR TITLE
Better pagination

### DIFF
--- a/internal/hub/tokens.go
+++ b/internal/hub/tokens.go
@@ -86,32 +86,32 @@ func (c *Client) CreateToken(description string, scopes []string) (*Token, error
 }
 
 //GetTokens calls the hub repo API and returns all the information on all tokens
-func (c *Client) GetTokens() ([]Token, error) {
+func (c *Client) GetTokens() ([]Token, int, error) {
 	u, err := url.Parse(c.domain + TokensURL)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	q := url.Values{}
 	q.Add("page_size", fmt.Sprintf("%v", itemsPerPage))
 	q.Add("page", "1")
 	u.RawQuery = q.Encode()
 
-	tokens, next, err := c.getTokensPage(u.String())
+	tokens, total, next, err := c.getTokensPage(u.String())
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if c.fetchAllElements {
 		for next != "" {
-			pageTokens, n, err := c.getTokensPage(next)
+			pageTokens, _, n, err := c.getTokensPage(next)
 			if err != nil {
-				return nil, err
+				return nil, 0, err
 			}
 			next = n
 			tokens = append(tokens, pageTokens...)
 		}
 	}
 
-	return tokens, nil
+	return tokens, total, nil
 }
 
 //GetToken calls the hub repo API and returns the information on one token
@@ -172,28 +172,28 @@ func (c *Client) RevokeToken(tokenUUID string) error {
 	return err
 }
 
-func (c *Client) getTokensPage(url string) ([]Token, string, error) {
+func (c *Client) getTokensPage(url string) ([]Token, int, string, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, "", err
+		return nil, 0, "", err
 	}
 	response, err := c.doRequest(req, WithHubToken(c.token))
 	if err != nil {
-		return nil, "", err
+		return nil, 0, "", err
 	}
 	var hubResponse hubTokenResponse
 	if err := json.Unmarshal(response, &hubResponse); err != nil {
-		return nil, "", err
+		return nil, 0, "", err
 	}
 	var tokens []Token
 	for _, result := range hubResponse.Results {
 		token, err := convertToken(result)
 		if err != nil {
-			return nil, "", err
+			return nil, 0, "", err
 		}
 		tokens = append(tokens, token)
 	}
-	return tokens, hubResponse.Next, nil
+	return tokens, hubResponse.Count, hubResponse.Next, nil
 }
 
 type hubTokenRequest struct {


### PR DESCRIPTION
Show how many listed elements we print with the total, and added a CTA to use --all flag to show all the elements

```sh
$ hub-tool tag ls nginx
You are currently on a free plan so your images may expire.
Images do not expire on Pro and Team plans, to find out more https://short/link
TAG                          DIGEST                                                                    STATUS              EXPIRES             LAST UPDATE         LAST PUSHED         LAST PULLED         SIZE
nginx:latest                 sha256:25f5435eda149152c2b73299c67c3d6de4c8714322bba56553978c14bf7155f9                                           3 days ago                                                  842.3MB
nginx:stable-perl            sha256:c607a04377d9f55fb6e557c18c85a6fdeca3b516d080273cc733dc9de988954f                                           3 days ago                                                  506.1MB
...
25/313 listed, use --all flag to show all the elements
```



**- A picture of a cute animal (not mandatory)**

![image](https://user-images.githubusercontent.com/31478878/96320358-7860d600-1012-11eb-8f54-5a0ae61ddf08.png)
