### PR TITLE
Pass the context down to http

### DIFF
--- a/cmd/hub-tool/main.go
+++ b/cmd/hub-tool/main.go
@@ -63,7 +63,7 @@ Please login to Docker Hub using the "docker login" command.`))
 	}
 
 	rootCmd := commands.NewRootCmd(dockerCli, hubClient, os.Args[0])
-	if err := rootCmd.Execute(); err != nil {
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/internal/commands/org/list.go
+++ b/internal/commands/org/list.go
@@ -17,6 +17,7 @@
 package org
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -65,7 +66,7 @@ func newListCmd(streams command.Streams, hubClient *hub.Client, parent string) *
 			metrics.Send(parent, listName)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(streams, hubClient, opts)
+			return runList(cmd.Context(), streams, hubClient, opts)
 		},
 	}
 	opts.AddFormatFlag(cmd.Flags())
@@ -73,8 +74,8 @@ func newListCmd(streams command.Streams, hubClient *hub.Client, parent string) *
 	return cmd
 }
 
-func runList(streams command.Streams, hubClient *hub.Client, opts listOptions) error {
-	organizations, err := hubClient.GetOrganizations()
+func runList(ctx context.Context, streams command.Streams, hubClient *hub.Client, opts listOptions) error {
+	organizations, err := hubClient.GetOrganizations(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/hub/organizations.go
+++ b/internal/hub/organizations.go
@@ -17,6 +17,7 @@
 package hub
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -39,7 +40,7 @@ type Organization struct {
 }
 
 //GetOrganizations lists all the organizations a user has joined
-func (c *Client) GetOrganizations() ([]Organization, error) {
+func (c *Client) GetOrganizations(ctx context.Context) ([]Organization, error) {
 	u, err := url.Parse(c.domain + OrganizationsURL)
 	if err != nil {
 		return nil, err
@@ -49,13 +50,13 @@ func (c *Client) GetOrganizations() ([]Organization, error) {
 	q.Add("page", "1")
 	u.RawQuery = q.Encode()
 
-	organizations, next, err := c.getOrganizationsPage(u.String())
+	organizations, next, err := c.getOrganizationsPage(ctx, u.String())
 	if err != nil {
 		return nil, err
 	}
 
 	for next != "" {
-		pageOrganizations, n, err := c.getOrganizationsPage(next)
+		pageOrganizations, n, err := c.getOrganizationsPage(ctx, next)
 		if err != nil {
 			return nil, err
 		}
@@ -66,11 +67,12 @@ func (c *Client) GetOrganizations() ([]Organization, error) {
 	return organizations, nil
 }
 
-func (c *Client) getOrganizationsPage(url string) ([]Organization, string, error) {
+func (c *Client) getOrganizationsPage(ctx context.Context, url string) ([]Organization, string, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, "", err
 	}
+	req = req.WithContext(ctx)
 	response, err := c.doRequest(req, WithHubToken(c.token))
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
**- What I did**

Pass the context down to http, that way we cancel the requests if the users ctrl+c.

I didn't want to make one big PR that adds context everywhere, I prefer to do the rest in followup PRs

**- How I did it**

**- How to verify it**

Call `hub-tool orgs list` and ctrl+c 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory)**

