### PR TITLE
Add cross compile for Linux arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ package-cross: cross ## Package the cross compiled binaries in tarballs for *nix
 		--output type=tar,dest=- \
 		--target package | gzip -9 > dist/$(BINARY_NAME)-linux-amd64.tar.gz
 	docker build $(BUILD_ARGS) . \
+		--platform linux/arm64 \
+		--output type=tar,dest=- \
+		--target package | gzip -9 > dist/$(BINARY_NAME)-linux-arm64.tar.gz
+	docker build $(BUILD_ARGS) . \
 		--platform darwin/amd64 \
 		--output type=tar,dest=- \
 		--target package | gzip -9 > dist/$(BINARY_NAME)-darwin-amd64.tar.gz

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -44,6 +44,7 @@ test-unit:
 
 cross:
 	GOOS=linux   GOARCH=amd64 $(STATIC_FLAGS) $(GO_BUILD) -o bin/$(BINARY_NAME)_linux_amd64 ./cmd/$(BINARY_NAME)
+	GOOS=linux   GOARCH=arm64 $(STATIC_FLAGS) $(GO_BUILD) -o bin/$(BINARY_NAME)_linux_arm64 ./cmd/$(BINARY_NAME)
 	GOOS=darwin  GOARCH=amd64 $(STATIC_FLAGS) $(GO_BUILD) -o bin/$(BINARY_NAME)_darwin_amd64 ./cmd/$(BINARY_NAME)
 	GOOS=windows GOARCH=amd64 $(STATIC_FLAGS) $(GO_BUILD) -o bin/$(BINARY_NAME)_windows_amd64.exe ./cmd/$(BINARY_NAME)
 


### PR DESCRIPTION
**- What I did**
* Add cross compile for Linux arm64

**- How to verify it**
```
$ make cross
$ file bin/hub-tool_linux_arm64
bin/hub-tool_linux_arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=Nhu88H7ZWuDYScuN3C50/BUgy8OT3NwdHQ6aFChp3/FiUb9Ke6-_cg-TkKfnza/cmqCK2XyRbH4K2B-YPKa, stripped
```

On top of #77 so only merge when that has been merged.