### PR TITLE
Use our own tabwriter that can write links

### DIFF
--- a/cmd/hub-tool/main.go
+++ b/cmd/hub-tool/main.go
@@ -28,7 +28,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/registry"
 
-	"github.com/docker/hub-tool/internal/color"
+	"github.com/docker/hub-tool/internal/ansi"
 	"github.com/docker/hub-tool/internal/commands"
 	"github.com/docker/hub-tool/internal/hub"
 )
@@ -54,7 +54,7 @@ func main() {
 	hubClient, err := hub.NewClient(authResolver, hub.WithContext(ctx))
 	if err != nil {
 		if hub.IsAuthenticationError(err) {
-			fmt.Println(color.Error(`You need to be logged in to Docker Hub to use this tool.
+			fmt.Println(ansi.Error(`You need to be logged in to Docker Hub to use this tool.
 Please login to Docker Hub using the "docker login" command.`))
 			os.Exit(1)
 		}

--- a/internal/ansi/ansi.go
+++ b/internal/ansi/ansi.go
@@ -14,9 +14,13 @@
    limitations under the License.
 */
 
-package color
+package ansi
 
-import "github.com/cli/cli/utils"
+import (
+	"fmt"
+
+	"github.com/cli/cli/utils"
+)
 
 var (
 	// Title color should be used for any important title
@@ -34,3 +38,8 @@ var (
 	// Emphasise color should be used with important content
 	Emphasise = utils.Green
 )
+
+// Link returns an ANSI terminal hyperlink
+func Link(url string, text string) string {
+	return fmt.Sprintf("\u001B]8;;%s\u0007%s\u001B]8;;\u0007", url, text)
+}

--- a/internal/commands/account/info.go
+++ b/internal/commands/account/info.go
@@ -24,10 +24,9 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/go-units"
-	"github.com/juju/ansiterm"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/hub-tool/internal/color"
+	"github.com/docker/hub-tool/internal/ansi"
 	"github.com/docker/hub-tool/internal/format"
 	"github.com/docker/hub-tool/internal/hub"
 	"github.com/docker/hub-tool/internal/metrics"
@@ -73,39 +72,32 @@ func runInfo(streams command.Streams, hubClient *hub.Client, opts infoOptions) e
 
 func printAccount(out io.Writer, value interface{}) error {
 	account := value.(account)
+
 	// print user info
-	w := ansiterm.NewTabWriter(out, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, color.Key("Username:")+"\t%s\n", account.User.UserName)
-	fmt.Fprintf(w, color.Key("Full name:")+"\t%s\n", account.User.FullName)
-	fmt.Fprintf(w, color.Key("Company:")+"\t%s\n", account.User.Company)
-	fmt.Fprintf(w, color.Key("Location:")+"\t%s\n", account.User.Location)
-	fmt.Fprintf(w, color.Key("Joined:")+"\t%s ago\n", units.HumanDuration(time.Since(account.User.Joined)))
-	fmt.Fprintf(w, color.Key("Plan:")+"\t%s\n", color.Emphasise(account.Plan.Name))
-	if err := w.Flush(); err != nil {
-		return err
-	}
+	fmt.Fprintf(out, ansi.Key("Username:")+"\t%s\n", account.User.UserName)
+	fmt.Fprintf(out, ansi.Key("Full name:")+"\t%s\n", account.User.FullName)
+	fmt.Fprintf(out, ansi.Key("Company:")+"\t%s\n", account.User.Company)
+	fmt.Fprintf(out, ansi.Key("Location:")+"\t%s\n", account.User.Location)
+	fmt.Fprintf(out, ansi.Key("Joined:")+"\t\t%s ago\n", units.HumanDuration(time.Since(account.User.Joined)))
+	fmt.Fprintf(out, ansi.Key("Plan:")+"\t\t%s\n", ansi.Emphasise(account.Plan.Name))
 
 	// print plan info
-	w = ansiterm.NewTabWriter(out, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, color.Key("Limits:")+"\n")
-	fmt.Fprintf(w, color.Key("%sSeats:")+"\t%v\n", pfx, account.Plan.Limits.Seats)
-	fmt.Fprintf(w, color.Key("%sPrivate repositories:")+"\t%v\n", pfx, account.Plan.Limits.PrivateRepos)
-	fmt.Fprintf(w, color.Key("%sParallel builds:")+"\t%v\n", pfx, account.Plan.Limits.ParallelBuilds)
-	fmt.Fprintf(w, color.Key("%sCollaborators:")+"\t%v\n", pfx, getLimit(account.Plan.Limits.Collaborators))
-	fmt.Fprintf(w, color.Key("%sTeams:")+"\t%v\n", pfx, getLimit(account.Plan.Limits.Teams))
-	return w.Flush()
+	fmt.Fprintf(out, ansi.Key("Limits:")+"\n")
+	fmt.Fprintf(out, ansi.Key("  Seats:")+"\t\t%v\n", account.Plan.Limits.Seats)
+	fmt.Fprintf(out, ansi.Key("  Private repositories:")+"\t%v\n", account.Plan.Limits.PrivateRepos)
+	fmt.Fprintf(out, ansi.Key("  Parallel builds:")+"\t%v\n", account.Plan.Limits.ParallelBuilds)
+	fmt.Fprintf(out, ansi.Key("  Collaborators:")+"\t%v\n", getLimit(account.Plan.Limits.Collaborators))
+	fmt.Fprintf(out, ansi.Key("  Teams:")+"\t\t%v\n", getLimit(account.Plan.Limits.Teams))
+
+	return nil
 }
 
 func getLimit(number int) string {
 	if number == 9999 {
-		return color.Emphasise("unlimited")
+		return ansi.Emphasise("unlimited")
 	}
 	return fmt.Sprintf("%v", number)
 }
-
-const (
-	pfx = "  "
-)
 
 type account struct {
 	User *hub.User

--- a/internal/commands/account/testdata/info.golden
+++ b/internal/commands/account/testdata/info.golden
@@ -1,12 +1,12 @@
-Username:  my-user-name
-Full name: My Full Name
-Company:   My Company
-Location:  MyLocation
-Joined:    Less than a second ago
-Plan:      free
+Username:	my-user-name
+Full name:	My Full Name
+Company:	My Company
+Location:	MyLocation
+Joined:		Less than a second ago
+Plan:		free
 Limits:
-  Seats:                1
-  Private repositories: 2
-  Parallel builds:      3
-  Collaborators:        unlimited
-  Teams:                unlimited
+  Seats:		1
+  Private repositories:	2
+  Parallel builds:	3
+  Collaborators:	unlimited
+  Teams:		unlimited

--- a/internal/commands/repo/rm.go
+++ b/internal/commands/repo/rm.go
@@ -26,7 +26,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/hub-tool/internal/color"
+	"github.com/docker/hub-tool/internal/ansi"
 	"github.com/docker/hub-tool/internal/hub"
 	"github.com/docker/hub-tool/internal/metrics"
 )
@@ -68,7 +68,7 @@ func runRm(streams command.Streams, hubClient *hub.Client, opts rmOptions, repos
 	}
 
 	if !opts.force {
-		fmt.Fprintln(streams.Out(), color.Warn("Please type the name of your repository to confirm deletion:"), namedRef.Name())
+		fmt.Fprintln(streams.Out(), ansi.Warn("Please type the name of your repository to confirm deletion:"), namedRef.Name())
 		reader := bufio.NewReader(streams.In())
 		input, _ := reader.ReadString('\n')
 		input = strings.ToLower(strings.TrimSpace(input))

--- a/internal/commands/tag/list.go
+++ b/internal/commands/tag/list.go
@@ -28,7 +28,7 @@ import (
 	"github.com/juju/ansiterm"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/hub-tool/internal/color"
+	"github.com/docker/hub-tool/internal/ansi"
 	"github.com/docker/hub-tool/internal/format"
 	"github.com/docker/hub-tool/internal/hub"
 	"github.com/docker/hub-tool/internal/metrics"
@@ -174,7 +174,7 @@ func printTags(out io.Writer, values interface{}) error {
 	for _, column := range defaultColumns {
 		headers = append(headers, column.header)
 	}
-	fmt.Fprintln(w, color.Header(strings.Join(headers, "\t")))
+	fmt.Fprintln(w, ansi.Header(strings.Join(headers, "\t")))
 	for _, tag := range h.tags {
 		var values []string
 		for _, column := range defaultColumns {
@@ -187,7 +187,7 @@ func printTags(out io.Writer, values interface{}) error {
 	}
 
 	if len(h.tags) < h.total {
-		fmt.Fprintln(out, color.Info(fmt.Sprintf("%v/%v listed, use --all flag to show all", len(h.tags), h.total)))
+		fmt.Fprintln(out, ansi.Info(fmt.Sprintf("%v/%v listed, use --all flag to show all", len(h.tags), h.total)))
 	}
 	return nil
 }
@@ -242,7 +242,7 @@ func promptCallToAction(out io.Writer, client accountInfo) error {
 		return nil
 	}
 
-	_, err = fmt.Fprint(out, color.Info(callToAction))
+	_, err = fmt.Fprint(out, ansi.Info(callToAction))
 	return err
 }
 

--- a/internal/commands/tag/rm.go
+++ b/internal/commands/tag/rm.go
@@ -26,7 +26,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/hub-tool/internal/color"
+	"github.com/docker/hub-tool/internal/ansi"
 	"github.com/docker/hub-tool/internal/hub"
 	"github.com/docker/hub-tool/internal/metrics"
 )
@@ -68,7 +68,7 @@ func runRm(streams command.Streams, hubClient *hub.Client, opts rmOptions, image
 	}
 
 	if !opts.force {
-		fmt.Fprintln(streams.Out(), color.Warn("Please type the name of your repository to confirm deletion:"), namedTaggedRef.Name())
+		fmt.Fprintln(streams.Out(), ansi.Warn("Please type the name of your repository to confirm deletion:"), namedTaggedRef.Name())
 		reader := bufio.NewReader(streams.In())
 		input, _ := reader.ReadString('\n')
 		input = strings.ToLower(strings.TrimSpace(input))

--- a/internal/commands/tag/testdata/printimage.golden
+++ b/internal/commands/tag/testdata/printimage.golden
@@ -1,35 +1,35 @@
 Manifest:
-  Name:      docker.io/library/image:latest
-  MediaType: mediatype/manifest
-  Digest:    sha256:abcdef
-  Platform:  os/arch/variant/osversion/feature1/feature2
-  Annotations:
-    annotation1: value1
-    annotation2: value2
-  Os/Arch:       os/arch
-  Author:        author
-  Created:       Less than a second ago
+Name:		docker.io/library/image:latest
+MediaType:	mediatype/manifest
+Digest:		sha256:abcdef
+Platform:	os/arch/variant/osversion/feature1/feature2
+Annotations:
+annotation1:	value1
+annotation2:	value2
+Os/Arch:	os/arch
+Author:	author
+Created:	Less than a second ago
 
 Config:
-  MediaType:     mediatype/config
-  Size:          123B
-  Digest:        sha256:beef
-  Command:       "./cmd parameter"
-  Entrypoint:    "./entrypoint parameter"
-  User:          user
-  Exposed ports: 80/tcp
-  Environment:
+MediaType:	mediatype/config
+Size:	123B
+Digest:	sha256:beef
+Command:	"./cmd parameter"
+Entrypoint:	"./entrypoint parameter"
+User:	user
+Exposed ports:	80/tcp
+Environment:
     KEY=VALUE
-  Volumes:
-    /volume
-  Working Directory: "/workingdir"
-  Labels:
+Volumes:
+/volume
+Working Directory:	"/workingdir"
+Labels:
     label="value"
-  Stop signal: SIGTERM
+Stop signal:		SIGTERM
 
 Layers:
-  MediaType: mediatype/layer
-  Size:      456B
-  Digest:    sha256:c0ffee
-  Command:   apt-get install
-  Created:   Less than a second ago
+MediaType:	mediatype/layer
+Size:	456B
+Digest:	sha256:c0ffee
+Command:	apt-get install
+Created:	Less than a second ago

--- a/internal/commands/token/create.go
+++ b/internal/commands/token/create.go
@@ -24,7 +24,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/hub-tool/internal/color"
+	"github.com/docker/hub-tool/internal/ansi"
 	"github.com/docker/hub-tool/internal/format"
 	"github.com/docker/hub-tool/internal/hub"
 	"github.com/docker/hub-tool/internal/metrics"
@@ -74,10 +74,10 @@ func printCreatedToken(out io.Writer, value interface{}) error {
 		fmt.Fprintln(out, helper.token.Token)
 		return nil
 	}
-	fmt.Fprintf(out, color.Emphasise("Personal Access Token successfully created!")+`
+	fmt.Fprintf(out, ansi.Emphasise("Personal Access Token successfully created!")+`
 
 When logging in from your Docker CLI client, use this token as a password.
-`+color.Header("Description:")+` %s
+`+ansi.Header("Description:")+` %s
 
 To use the access token from your Docker CLI client:
 1. Run docker login --username %s
@@ -85,12 +85,12 @@ To use the access token from your Docker CLI client:
 
     %s
 
-`+color.Warn(`WARNING: This access token will only be displayed once.
+`+ansi.Warn(`WARNING: This access token will only be displayed once.
 It will not be stored and cannot be retrieved. Please be sure to save it now.
 `),
 		helper.token.Description,
 		helper.userName,
-		color.Emphasise(helper.token.Token))
+		ansi.Emphasise(helper.token.Token))
 	return nil
 }
 

--- a/internal/commands/token/inspect.go
+++ b/internal/commands/token/inspect.go
@@ -29,7 +29,7 @@ import (
 	"github.com/juju/ansiterm"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/hub-tool/internal/color"
+	"github.com/docker/hub-tool/internal/ansi"
 	"github.com/docker/hub-tool/internal/format"
 	"github.com/docker/hub-tool/internal/hub"
 	"github.com/docker/hub-tool/internal/metrics"
@@ -81,17 +81,17 @@ func printInspectToken(out io.Writer, value interface{}) error {
 	token := value.(*hub.Token)
 
 	w := ansiterm.NewTabWriter(out, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, color.Title("Token:")+"\n")
-	fmt.Fprintf(w, color.Key("%sUUID:")+"\t%s\n", prefix, token.UUID)
+	fmt.Fprintf(w, ansi.Title("Token:")+"\n")
+	fmt.Fprintf(w, ansi.Key("%sUUID:")+"\t%s\n", prefix, token.UUID)
 	if token.Description != "" {
-		fmt.Fprintf(w, color.Key("%sDescription:")+"\t%s\n", prefix, token.Description)
+		fmt.Fprintf(w, ansi.Key("%sDescription:")+"\t%s\n", prefix, token.Description)
 	}
-	fmt.Fprintf(w, color.Key("%sIs Active:")+"\t%v\n", prefix, token.IsActive)
-	fmt.Fprintf(w, color.Key("%sCreated:")+"\t%s\n", prefix, fmt.Sprintf("%s ago", units.HumanDuration(time.Since(token.CreatedAt))))
-	fmt.Fprintf(w, color.Key("%sLast Used:")+"\t%s\n", prefix, getLastUsed(token.LastUsed))
-	fmt.Fprintf(w, color.Key("%sCreator User Agent:")+"\t%s\n", prefix, token.CreatorUA)
-	fmt.Fprintf(w, color.Key("%sCreator IP:")+"\t%s\n", prefix, token.CreatorIP)
-	fmt.Fprintf(w, color.Key("%sGenerated:")+"\t%s\n", prefix, getGeneratedBy(token))
+	fmt.Fprintf(w, ansi.Key("%sIs Active:")+"\t%v\n", prefix, token.IsActive)
+	fmt.Fprintf(w, ansi.Key("%sCreated:")+"\t%s\n", prefix, fmt.Sprintf("%s ago", units.HumanDuration(time.Since(token.CreatedAt))))
+	fmt.Fprintf(w, ansi.Key("%sLast Used:")+"\t%s\n", prefix, getLastUsed(token.LastUsed))
+	fmt.Fprintf(w, ansi.Key("%sCreator User Agent:")+"\t%s\n", prefix, token.CreatorUA)
+	fmt.Fprintf(w, ansi.Key("%sCreator IP:")+"\t%s\n", prefix, token.CreatorIP)
+	fmt.Fprintf(w, ansi.Key("%sGenerated:")+"\t%s\n", prefix, getGeneratedBy(token))
 	return w.Flush()
 }
 

--- a/internal/commands/token/list.go
+++ b/internal/commands/token/list.go
@@ -28,7 +28,7 @@ import (
 	"github.com/juju/ansiterm"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/hub-tool/internal/color"
+	"github.com/docker/hub-tool/internal/ansi"
 	"github.com/docker/hub-tool/internal/format"
 	"github.com/docker/hub-tool/internal/hub"
 	"github.com/docker/hub-tool/internal/metrics"
@@ -106,7 +106,7 @@ func printTokens(out io.Writer, values interface{}) error {
 	for _, column := range defaultColumns {
 		headers = append(headers, column.header)
 	}
-	fmt.Fprintln(w, color.Header(strings.Join(headers, "\t")))
+	fmt.Fprintln(w, ansi.Header(strings.Join(headers, "\t")))
 	for _, token := range h.tokens {
 		var values []string
 		for _, column := range defaultColumns {
@@ -119,7 +119,7 @@ func printTokens(out io.Writer, values interface{}) error {
 	}
 
 	if len(h.tokens) < h.total {
-		fmt.Fprintln(out, color.Info(fmt.Sprintf("%v/%v listed, use --all flag to show all", len(h.tokens), h.total)))
+		fmt.Fprintln(out, ansi.Info(fmt.Sprintf("%v/%v listed, use --all flag to show all", len(h.tokens), h.total)))
 	}
 	return nil
 }

--- a/internal/commands/token/revoke.go
+++ b/internal/commands/token/revoke.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/hub-tool/internal/color"
+	"github.com/docker/hub-tool/internal/ansi"
 	"github.com/docker/hub-tool/internal/hub"
 	"github.com/docker/hub-tool/internal/metrics"
 )
@@ -64,7 +64,7 @@ func runRevoke(streams command.Streams, hubClient *hub.Client, opts revokeOption
 	}
 
 	if !opts.force {
-		fmt.Fprintf(streams.Out(), color.Warn("WARNING: This action is irreversible.")+`
+		fmt.Fprintf(streams.Out(), ansi.Warn("WARNING: This action is irreversible.")+`
 By confirming, you will permanently delete the access token.
 Revoking a token will invalidate your credentials on all Docker clients currently authenticated with this token.
 
@@ -80,6 +80,6 @@ Please type your username %q to confirm deletion: `, hubClient.AuthConfig.Userna
 	if err := hubClient.RevokeToken(u.String()); err != nil {
 		return err
 	}
-	fmt.Fprintln(streams.Out(), color.Emphasise("Revoked"), u)
+	fmt.Fprintln(streams.Out(), ansi.Emphasise("Revoked"), u)
 	return nil
 }

--- a/internal/commands/token/update.go
+++ b/internal/commands/token/update.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/hub-tool/internal/color"
+	"github.com/docker/hub-tool/internal/ansi"
 	"github.com/docker/hub-tool/internal/hub"
 	"github.com/docker/hub-tool/internal/metrics"
 )
@@ -78,6 +78,6 @@ func runUpdate(streams command.Streams, hubClient *hub.Client, cmd *cobra.Comman
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(streams.Out(), color.Emphasise("Updated"), u.String())
+	fmt.Fprintln(streams.Out(), ansi.Emphasise("Updated"), u.String())
 	return nil
 }

--- a/internal/format/tabwriter/tabwriter.go
+++ b/internal/format/tabwriter/tabwriter.go
@@ -1,0 +1,108 @@
+/*
+   Copyright 2020 Docker Hub Tool authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tabwriter
+
+import (
+	"fmt"
+	"io"
+)
+
+type tw struct {
+	idx     int
+	lines   [][]string
+	widths  [][]int
+	w       io.Writer
+	padding string
+}
+
+// TabWriter interface :)
+type TabWriter interface {
+	Column(string, int)
+	Line()
+	Flush() error
+}
+
+// New creates a new tab writer that output to the io.Writer
+func New(w io.Writer, padding string) TabWriter {
+	return &tw{
+		idx:     0,
+		lines:   [][]string{},
+		widths:  [][]int{},
+		w:       w,
+		padding: padding,
+	}
+}
+
+func (t *tw) Column(s string, l int) {
+	if len(t.lines) <= t.idx {
+		t.lines = append(t.lines, []string{})
+		t.widths = append(t.widths, []int{})
+	}
+
+	t.lines[t.idx] = append(t.lines[t.idx], s)
+	t.widths[t.idx] = append(t.widths[t.idx], l)
+}
+
+func (t *tw) Line() {
+	t.idx++
+}
+
+func (t *tw) Flush() error {
+	maxs := []int{}
+	for i := range t.lines[0] {
+		maxs = append(maxs, t.max(i))
+	}
+
+	for k, l := range t.lines {
+		for i, c := range l {
+			pad := ""
+			if i != 0 {
+				pad = t.pad(maxs[i-1], t.widths[k][i-1])
+			}
+			if _, err := fmt.Fprint(t.w, pad+c); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(t.w, ""); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *tw) pad(max int, l int) string {
+	ret := t.padding
+	for i := 0; i < max-l; i++ {
+		ret += " "
+	}
+	return ret
+}
+
+func (t *tw) max(col int) int {
+	w := 0
+	for _, width := range t.widths {
+		for i, ww := range width {
+			if i == col {
+				if ww > w {
+					w = ww
+				}
+			}
+		}
+	}
+	return w
+}

--- a/internal/format/tabwriter/tabwriter_test.go
+++ b/internal/format/tabwriter/tabwriter_test.go
@@ -1,0 +1,50 @@
+/*
+   Copyright 2020 Docker Hub Tool authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tabwriter
+
+import (
+	"bytes"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
+)
+
+func TestSimple(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	tw := New(b, "")
+	s := "test"
+	tw.Column(s, len(s))
+	err := tw.Flush()
+	assert.NilError(t, err)
+	assert.Equal(t, s+"\n", b.String())
+}
+
+func TestTwoLines(t *testing.T) {
+	b := bytes.NewBuffer(nil)
+	tw := New(b, " ")
+	first := "test"
+	second := "docker"
+	tw.Column(first, len(first))
+	tw.Column(first, len(first))
+	tw.Line()
+	tw.Column(second, len(second))
+	tw.Column(second, len(second))
+	err := tw.Flush()
+	assert.NilError(t, err)
+	golden.Assert(t, b.String(), "twolines.golden")
+}

--- a/internal/format/tabwriter/testdata/twolines.golden
+++ b/internal/format/tabwriter/testdata/twolines.golden
@@ -1,0 +1,2 @@
+test   test
+docker docker


### PR DESCRIPTION
**- What I did**

Created a tabwriter that can write tables with colors and links

Added links to
* orgs list
* repos list

The link will open a page in the browser to the corresponding org/repo page on hub.docker.com.

<img width="1481" alt="Screenshot 2020-10-21 at 5 35 27 PM" src="https://user-images.githubusercontent.com/99933/96743052-e1a26980-13c3-11eb-8570-968ab2875214.png">

<img width="1481" alt="Screenshot 2020-10-21 at 5 35 43 PM" src="https://user-images.githubusercontent.com/99933/96743065-e404c380-13c3-11eb-8ce2-7d3f1909e508.png">

**Note**: I didn't completely remove `ansiterm` because the PR is already big enough, will remove in a followup PR