### PR TITLE
Fix version flag help

### DIFF
--- a/e2e/version_test.go
+++ b/e2e/version_test.go
@@ -26,15 +26,22 @@ import (
 	"github.com/docker/hub-tool/internal"
 )
 
-func TestVersion(t *testing.T) {
+func TestVersionCmd(t *testing.T) {
+	cmd, cleanup := hubToolCmd(t, "version")
+	defer cleanup()
+
+	output := icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined()
+	expected := fmt.Sprintf("Version:    %s\nGit commit: %s\n", internal.Version, internal.GitCommit)
+
+	assert.Equal(t, output, expected)
+}
+
+func TestVersionFlag(t *testing.T) {
 	cmd, cleanup := hubToolCmd(t, "--version")
 	defer cleanup()
 
 	output := icmd.RunCmd(cmd).Assert(t, icmd.Success).Combined()
-	expected := fmt.Sprintf(
-		`Version:    %s
-Git commit: %s
-`, internal.Version, internal.GitCommit)
+	expected := fmt.Sprintf("Docker Hub Tool %s, build %s\n", internal.Version, internal.GitCommit[:7])
 
 	assert.Equal(t, output, expected)
 }


### PR DESCRIPTION
**- What I did**
Fixed: #51 

```console
$ ./bin/hub-tool version
Version:    v0.1.0-27-gbe1122d
Git commit: be1122d10ca552493dd50777c396177d2f94994f
```

```console
$ ./bin/hub-tool --version
Docker Hub Tool v0.1.0-27-gbe1122d, build be1122d
```
```console
$ ./bin/hub-tool --help   
...
      --version   Display the version of this tool
```

