### PR TITLE
Fix tag inspect --format json

### DIFF
--- a/internal/commands/tag/inspect_test.go
+++ b/internal/commands/tag/inspect_test.go
@@ -97,7 +97,7 @@ func TestPrintImage(t *testing.T) {
 	}
 	ref, err := reference.ParseDockerRef("image:latest")
 	assert.NilError(t, err)
-	image := Image{ref, manifest, config, manifestDescriptor}
+	image := Image{ref.Name(), manifest, config, manifestDescriptor}
 
 	out := bytes.NewBuffer(nil)
 	err = printImage(out, &image)

--- a/internal/commands/tag/testdata/printimage.golden
+++ b/internal/commands/tag/testdata/printimage.golden
@@ -1,5 +1,5 @@
 Manifest:
-Name:		docker.io/library/image:latest
+Name:		docker.io/library/image
 MediaType:	mediatype/manifest
 Digest:		sha256:abcdef
 Platform:	os/arch/variant/osversion/feature1/feature2
@@ -12,7 +12,7 @@ Created:	Less than a second ago
 
 Config:
 MediaType:	mediatype/config
-Size:	123B
+Size:		123B
 Digest:	sha256:beef
 Command:	"./cmd parameter"
 Entrypoint:	"./entrypoint parameter"
@@ -29,7 +29,7 @@ Stop signal:		SIGTERM
 
 Layers:
 MediaType:	mediatype/layer
-Size:	456B
+Size:		456B
 Digest:	sha256:c0ffee
 Command:	apt-get install
 Created:	Less than a second ago


### PR DESCRIPTION
**- What I did**

Fixed tag inspect --format json, image name becomes a string because reference.Named is an interface and not a struct.

```
❯ ./bin/hub-tool tag inspect --format json justincormack/nsenter1
{
  "Name": "docker.io/justincormack/nsenter1",
  "Manifest": {
    "schemaVersion": 2,
    "config": {
      "mediaType": "application/vnd.docker.container.image.v1+json",
      "digest": "sha256:c81481184b1b001f225769d1482b360b4be18fe7dd53fa93cdbd45d568e905a7",
      "size": 1552
    },
    "layers": [
      {
        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
        "digest": "sha256:5bc638ae6f98f853c3e62a7b84c971cc7ceef4c6144b600c5b5ac7bf7cc72344",
        "size": 32021
      }
    ]
  },
  "Config": {
    "created": "2018-01-17T11:36:39.275322941Z",
    "architecture": "amd64",
    "os": "linux",
    "config": {
      "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
      ],
      "Entrypoint": [
        "/usr/bin/nsenter1"
      ]
    },
    "rootfs": {
      "type": "layers",
      "diff_ids": [
        "sha256:c43e635df3c82c2f4ce61495e8440e23ed6001c7c26c8353e6b743459a97d60e"
      ]
    },
    "history": [
      {
        "created": "2018-01-17T11:36:39.073955175Z",
        "created_by": "/bin/sh -c #(nop) COPY file:32a3175cae8425b06e9da06d4bd3a6ce15c2fbaa103ed7b8e6d19356e4fd3496 in /usr/bin/nsenter1 "
      },
      {
        "created": "2018-01-17T11:36:39.275322941Z",
        "created_by": "/bin/sh -c #(nop)  ENTRYPOINT [\"/usr/bin/nsenter1\"]",
        "empty_layer": true
      }
    ]
  },
  "Descriptor": {
    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    "digest": "sha256:5af0be5e42ebd55eea2c593e4622f810065c3f45bb805eaacf43f08f3d06ffd8",
    "size": 526
  }
}
```

Fixes #56 
