### PR TITLE
registry-1.docker.io is the canonical registry hostname

### DIFF
--- a/internal/hub/instances.go
+++ b/internal/hub/instances.go
@@ -32,7 +32,7 @@ var (
 	hub = Instance{
 		APIHubBaseURL: "https://hub.docker.com",
 		RegistryInfo: &registry.IndexInfo{
-			Name:     "registry.docker.io",
+			Name:     "registry-1.docker.io",
 			Mirrors:  nil,
 			Secure:   true,
 			Official: true,


### PR DESCRIPTION
yes I'm skipping the template. Sorry, but it's not worth it for this change. Just found that `registry.docker.io` is actually a redirect to `registry-1.docker.io`, so the canonical one is `registry-1.docker.io`