### PR TITLE
Fix typo on env vars

### DIFF
--- a/internal/hub/instances.go
+++ b/internal/hub/instances.go
@@ -43,7 +43,7 @@ var (
 // getInstance returns the current hub instance, which can be overridden by
 // DOCKER_REGISTRY_URL and DOCKER_REGISTRY_URL env var
 func getInstance() *Instance {
-	apiBaseURL := os.Getenv("DOCKER_REGISTRY_URL")
+	apiBaseURL := os.Getenv("DOCKER_HUB_API_URL")
 	reg := os.Getenv("DOCKER_REGISTRY_URL")
 
 	if apiBaseURL != "" && reg != "" {


### PR DESCRIPTION
Fix typo, we should have 2 different env vars: DOCKER_REGISTRY_URL and DOCKER_API_URL

![image](https://user-images.githubusercontent.com/31478878/98372183-a5b30980-203d-11eb-922d-eccfbd57af10.png)

