### PR TITLE
Return server message on bad status

### DIFF
--- a/internal/hub/client.go
+++ b/internal/hub/client.go
@@ -177,6 +177,15 @@ func (c *Client) doRequest(req *http.Request, reqOps ...RequestOp) ([]byte, erro
 		defer resp.Body.Close() //nolint:errcheck
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		buf, err := ioutil.ReadAll(resp.Body)
+		if err == nil {
+			var body map[string]string
+			if err := json.Unmarshal(buf, &body); err == nil {
+				if msg, ok := body["message"]; ok {
+					return nil, fmt.Errorf("bad status code %q: %s", resp.Status, msg)
+				}
+			}
+		}
 		return nil, fmt.Errorf("bad status code %q", resp.Status)
 	}
 	buf, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
**- What I did**
Improved the error message when getting a response with a 403 status code.

**- How I did it**
Return the server message (if available) when getting a non 2xx status code from the server.

**- How to verify it**
Before:
```console
$ ./bin/hub-tool account info      
Error: bad status code "403 Forbidden"
```

After:
```console
$ ./bin/hub-tool account info
Error: bad status code "403 Forbidden": access to the resource is forbidden with personal access token
```

Closes: #71 