### PR TITLE
Handle ctrl+C in tag rm prompt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.3 // indirect
 	github.com/miekg/pkcs11 v1.0.3 // indirect
 	github.com/opencontainers/image-spec v1.0.1
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208


### PR DESCRIPTION
**- What I did**
Fix ctrl+C handling in tag rm prompt.

**- How I did it**
Read user input in goroutine so that we can handle the context being canceled.

**- How to verify it**
```console
$ ./bin/hub-tool tag rm ccrone/alpine
Please type the name of your tag to confirm deletion: ccrone/alpine:latest
^CError: canceled
```

Fixes: #110