### PR TITLE
Improve error message from server

### DIFF
--- a/internal/hub/client.go
+++ b/internal/hub/client.go
@@ -181,9 +181,13 @@ func (c *Client) doRequest(req *http.Request, reqOps ...RequestOp) ([]byte, erro
 		if err == nil {
 			var body map[string]string
 			if err := json.Unmarshal(buf, &body); err == nil {
-				if msg, ok := body["message"]; ok {
-					return nil, fmt.Errorf("bad status code %q: %s", resp.Status, msg)
+				for _, k := range []string{"message", "detail"} {
+					if msg, ok := body[k]; ok {
+						return nil, fmt.Errorf("bad status code %q: %s", resp.Status, msg)
+					}
 				}
+				// If not in our key list, print the whole JSON body
+				return nil, fmt.Errorf("bad status code %q: %s", resp.Status, buf)
 			}
 		}
 		return nil, fmt.Errorf("bad status code %q", resp.Status)


### PR DESCRIPTION
**- What I did**
Improve logic for fetching server error and printing it out.

**- How I did it**
Found that `tag rm` didn't print the correct error message and found that the server stores the message with the key "detail" instead of "message".

If the response body is JSON and we don't find a message, I print all the JSON.

**- How to verify it**
detail example:
```console
$ ./bin/hub-tool tag rm ccrone/alpine
Please type the name of your tag to confirm deletion: ccrone/alpine:latest
ccrone/alpine:latest
Error: bad status code "403 FORBIDDEN": access to the resource is forbidden with personal access token
```

JSON example:
```console
$ ./bin/hub-tool tag rm ccrone/alpine
Please type the name of your tag to confirm deletion: ccrone/alpine:latest
ccrone/alpine:latest
Error: bad status code "403 FORBIDDEN": {"detail": "access to the resource is forbidden with personal access token"}
```

Related to: #71 