### PR TITLE
Add logging to Hub client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/miekg/pkcs11 v1.0.3 // indirect
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208


### PR DESCRIPTION
**- What I did**
Added a visible `--verbose` flag and a hidden `--trace` flag to help debugging. I've only added logs to the Hub client for now.

**- How to verify it**
Note that `--trace` his hidden in the help
```console
$ ./bin/hub-tool --help
A tool to manage your Docker Hub images

Usage:
  ./bin/hub-tool
  ./bin/hub-tool [command]

Available Commands:
  account     Manage your account
  help        Help about any command
  org         Manage organizations
  repo        Manage repositories
  tag         Manage tags
  token       Manage Personal Access Tokens
  version     Version information about this tool

Flags:
  -h, --help      help for ./bin/hub-tool
      --verbose   Print logs
      --version   Display the version of this tool

Use "./bin/hub-tool [command] --help" for more information about a command.
```

```console
$ ./bin/hub-tool account info --verbose
DEBU[0000] HTTP GET on: https://hub.docker.com/v2/user/ 
DEBU[0000] HTTP GET on: https://hub.docker.com/api/billing/v4/accounts/7cc20906ae28482e822084af305ae76a/hub-plan 
DEBU[0000] bad status code "403 Forbidden": {"message":"access to the resource is forbidden with personal access token"} 
Error: bad status code "403 Forbidden": access to the resource is forbidden with personal access token
```

```console
$ /bin/hub-tool account info --trace  
DEBU[0000] HTTP GET on: https://hub.docker.com/v2/user/
...
<lots of raw request data>
```

