### PR TITLE
Add list alias for all ls commands

### DIFF
--- a/internal/commands/org/list.go
+++ b/internal/commands/org/list.go
@@ -67,6 +67,7 @@ func newListCmd(streams command.Streams, hubClient *hub.Client, parent string) *
 	var opts listOptions
 	cmd := &cobra.Command{
 		Use:                   listName,
+		Aliases:               []string{"list"},
 		Short:                 "List all the organizations",
 		Args:                  cli.NoArgs,
 		DisableFlagsInUseLine: true,

--- a/internal/commands/repo/list.go
+++ b/internal/commands/repo/list.go
@@ -79,6 +79,7 @@ func newListCmd(streams command.Streams, hubClient *hub.Client, parent string) *
 	var opts listOptions
 	cmd := &cobra.Command{
 		Use:                   listName + " [ORGANIZATION]",
+		Aliases:               []string{"list"},
 		Short:                 "List all the repositories from your account or an organization",
 		Args:                  cli.RequiresMaxArgs(1),
 		DisableFlagsInUseLine: true,

--- a/internal/commands/tag/list.go
+++ b/internal/commands/tag/list.go
@@ -116,6 +116,7 @@ func newListCmd(streams command.Streams, hubClient *hub.Client, parent string) *
 	var opts listOptions
 	cmd := &cobra.Command{
 		Use:                   lsName + " [OPTION] REPOSITORY",
+		Aliases:               []string{"list"},
 		Short:                 "List all the images in a repository",
 		Args:                  cli.ExactArgs(1),
 		DisableFlagsInUseLine: true,

--- a/internal/commands/token/list.go
+++ b/internal/commands/token/list.go
@@ -73,6 +73,7 @@ func newListCmd(streams command.Streams, hubClient *hub.Client, parent string) *
 	var opts listOptions
 	cmd := &cobra.Command{
 		Use:                   lsName + " [OPTION]",
+		Aliases:               []string{"list"},
 		Short:                 "List all the Personal Access Tokens",
 		Args:                  cli.NoArgs,
 		DisableFlagsInUseLine: true,


### PR DESCRIPTION
My fingers don't want to write `ls` they always write `list`...