### PR TITLE
Improve account info command to check status about an organization

### DIFF
--- a/internal/commands/account/info_test.go
+++ b/internal/commands/account/info_test.go
@@ -29,9 +29,9 @@ import (
 
 func TestInfoOutput(t *testing.T) {
 	account := account{
-		User: &hub.User{
+		Account: &hub.Account{
 			ID:       "id",
-			UserName: "my-user-name",
+			Name:     "my-user-name",
 			FullName: "My Full Name",
 			Location: "MyLocation",
 			Company:  "My Company",
@@ -46,6 +46,11 @@ func TestInfoOutput(t *testing.T) {
 				Collaborators:  9999,
 				ParallelBuilds: 3,
 			},
+		},
+		Consumption: &hub.Consumption{
+			Seats:               0,
+			PrivateRepositories: 1,
+			Teams:               2,
 		},
 	}
 	buf := bytes.NewBuffer(nil)

--- a/internal/commands/account/testdata/info.golden
+++ b/internal/commands/account/testdata/info.golden
@@ -1,12 +1,12 @@
-Username:	my-user-name
+Name:		my-user-name
 Full name:	My Full Name
 Company:	My Company
 Location:	MyLocation
 Joined:		Less than a second ago
 Plan:		free
 Limits:
-  Seats:		1
-  Private repositories:	2
-  Parallel builds:	3
-  Collaborators:	unlimited
+  Seats:		0/1
+  Private repositories:	1/2
   Teams:		unlimited
+  Collaborators:	unlimited
+  Parallel builds:	3

--- a/internal/commands/repo/list.go
+++ b/internal/commands/repo/list.go
@@ -78,7 +78,7 @@ type listOptions struct {
 func newListCmd(streams command.Streams, hubClient *hub.Client, parent string) *cobra.Command {
 	var opts listOptions
 	cmd := &cobra.Command{
-		Use:                   listName + " [ORGANIZATION]",
+		Use:                   listName + " [OPTIONS] [ORGANIZATION]",
 		Aliases:               []string{"list"},
 		Short:                 "List all the repositories from your account or an organization",
 		Args:                  cli.RequiresMaxArgs(1),

--- a/internal/hub/client.go
+++ b/internal/hub/client.go
@@ -300,6 +300,9 @@ func (c *Client) doRequest(req *http.Request, reqOps ...RequestOp) ([]byte, erro
 	}
 	log.Tracef("HTTP response: %+v", resp)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if resp.StatusCode == http.StatusForbidden {
+			return nil, &forbiddenError{}
+		}
 		buf, err := ioutil.ReadAll(resp.Body)
 		log.Debugf("bad status code %q: %s", resp.Status, buf)
 		if err == nil {

--- a/internal/hub/consumption.go
+++ b/internal/hub/consumption.go
@@ -1,0 +1,99 @@
+/*
+   Copyright 2020 Docker Hub Tool authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package hub
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+//Consumption represents current user or org consumption
+type Consumption struct {
+	Seats               int
+	PrivateRepositories int
+	Teams               int
+}
+
+//GetOrgConsumption return the current organization consumption
+func (c *Client) GetOrgConsumption(org string) (*Consumption, error) {
+	var (
+		members      int
+		privateRepos int
+		teams        int
+	)
+	c.fetchAllElements = true
+	eg, _ := errgroup.WithContext(context.Background())
+	eg.Go(func() error {
+		count, err := c.GetMembersCount(org)
+		if err != nil {
+			return err
+		}
+		members = count
+		return nil
+	})
+	eg.Go(func() error {
+		count, err := c.GetTeamsCount(org)
+		if err != nil {
+			return err
+		}
+		teams = count
+		return nil
+	})
+	eg.Go(func() error {
+		repos, _, err := c.GetRepositories(org)
+		if err != nil {
+			return err
+		}
+		for _, r := range repos {
+			if r.IsPrivate {
+				privateRepos++
+			}
+		}
+		return nil
+	})
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return &Consumption{
+		Seats:               members,
+		PrivateRepositories: privateRepos,
+		Teams:               teams,
+	}, nil
+}
+
+//GetUserConsumption return the current user consumption
+func (c *Client) GetUserConsumption(user string) (*Consumption, error) {
+	c.fetchAllElements = true
+	privateRepos := 0
+	repos, _, err := c.GetRepositories(user)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range repos {
+		if r.IsPrivate {
+			privateRepos++
+		}
+	}
+	return &Consumption{
+		Seats:               1,
+		PrivateRepositories: privateRepos,
+		Teams:               0,
+	}, nil
+}

--- a/internal/hub/error.go
+++ b/internal/hub/error.go
@@ -44,3 +44,15 @@ func IsInvalidTokenError(err error) bool {
 	_, ok := err.(*invalidTokenError)
 	return ok
 }
+
+type forbiddenError struct{}
+
+func (f forbiddenError) Error() string {
+	return "operation not permitted"
+}
+
+// IsForbiddenError check if the error type is a forbidden error
+func IsForbiddenError(err error) bool {
+	_, ok := err.(*forbiddenError)
+	return ok
+}

--- a/internal/hub/error_test.go
+++ b/internal/hub/error_test.go
@@ -32,3 +32,8 @@ func TestIsInvalidTokenError(t *testing.T) {
 	assert.Assert(t, IsInvalidTokenError(&invalidTokenError{}))
 	assert.Assert(t, !IsInvalidTokenError(errors.New("")))
 }
+
+func TestIsForbiddenError(t *testing.T) {
+	assert.Assert(t, IsForbiddenError(&forbiddenError{}))
+	assert.Assert(t, !IsForbiddenError(errors.New("")))
+}

--- a/internal/hub/members.go
+++ b/internal/hub/members.go
@@ -65,6 +65,32 @@ func (c *Client) GetMembers(organization string) ([]Member, error) {
 	return members, nil
 }
 
+// GetMembersCount return the number of members in an organization
+func (c *Client) GetMembersCount(organization string) (int, error) {
+	u, err := url.Parse(c.domain + fmt.Sprintf(MembersURL, organization))
+	if err != nil {
+		return 0, err
+	}
+	q := url.Values{}
+	q.Add("page_size", "1")
+	q.Add("page", "1")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return 0, err
+	}
+	response, err := c.doRequest(req, withHubToken(c.token))
+	if err != nil {
+		return 0, err
+	}
+	var hubResponse hubMemberResponse
+	if err := json.Unmarshal(response, &hubResponse); err != nil {
+		return 0, err
+	}
+	return hubResponse.Count, nil
+}
+
 // GetMembersPerTeam returns the members of a team in an organization
 func (c *Client) GetMembersPerTeam(organization, team string) ([]Member, error) {
 	u := c.domain + fmt.Sprintf(MembersPerTeamURL, organization, team)

--- a/internal/hub/teams.go
+++ b/internal/hub/teams.go
@@ -67,6 +67,32 @@ func (c *Client) GetTeams(organization string) ([]Team, error) {
 	return teams, nil
 }
 
+//GetTeamsCount returns the number of teams in an organization
+func (c *Client) GetTeamsCount(organization string) (int, error) {
+	u, err := url.Parse(c.domain + fmt.Sprintf(GroupsURL, organization))
+	if err != nil {
+		return 0, err
+	}
+	q := url.Values{}
+	q.Add("page_size", "1")
+	q.Add("page", "1")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return 0, err
+	}
+	response, err := c.doRequest(req, withHubToken(c.token))
+	if err != nil {
+		return 0, err
+	}
+	var hubResponse hubGroupResponse
+	if err := json.Unmarshal(response, &hubResponse); err != nil {
+		return 0, err
+	}
+	return hubResponse.Count, nil
+}
+
 func (c *Client) getTeamsPage(url, organization string) ([]Team, string, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/internal/hub/user.go
+++ b/internal/hub/user.go
@@ -28,10 +28,10 @@ const (
 	UserURL = "/v2/user/"
 )
 
-//User represents the user information
-type User struct {
+//Account represents a user or organization information
+type Account struct {
 	ID       string
-	UserName string
+	Name     string
 	FullName string
 	Location string
 	Company  string
@@ -39,7 +39,7 @@ type User struct {
 }
 
 //GetUserInfo returns the information on the user retrieved from Hub
-func (c *Client) GetUserInfo() (*User, error) {
+func (c *Client) GetUserInfo() (*Account, error) {
 	u, err := url.Parse(c.domain + UserURL)
 	if err != nil {
 		return nil, err
@@ -56,9 +56,9 @@ func (c *Client) GetUserInfo() (*User, error) {
 	if err := json.Unmarshal(response, &hubResponse); err != nil {
 		return nil, err
 	}
-	return &User{
+	return &Account{
 		ID:       hubResponse.ID,
-		UserName: hubResponse.UserName,
+		Name:     hubResponse.UserName,
 		FullName: hubResponse.FullName,
 		Location: hubResponse.Location,
 		Company:  hubResponse.Company,


### PR DESCRIPTION
**- What I did**
Added an argument to the `account info` command to get info from an organization.
Also fetches current repo, seats and teams consumption.

<img width="483" alt="Screen Shot 2021-01-04 at 10 32 54" src="https://user-images.githubusercontent.com/31478878/103521070-73c0f680-4e78-11eb-8f9f-521aefd0d25b.png">
<img width="564" alt="Screen Shot 2021-01-04 at 10 33 05" src="https://user-images.githubusercontent.com/31478878/103521073-758aba00-4e78-11eb-93bc-2f55c657456a.png">


**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/31478878/103520525-93a3ea80-4e77-11eb-99fb-984e3c3a14e0.png)

