### PR TITLE
fix the verbose logout error displayed when the user is already disco…

### DIFF
--- a/internal/credentials/store.go
+++ b/internal/credentials/store.go
@@ -124,8 +124,24 @@ func (s *store) Store(auth Auth) error {
 	})
 }
 
+func (s *store) exists(serverAddress string) (bool, error) {
+	authConfig, err := s.s.Get(serverAddress)
+	if err != nil {
+		return false, err
+	}
+
+	if (clitypes.AuthConfig{}) == authConfig {
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func (s *store) Erase() error {
 	if err := s.s.Erase(hubToolKey); err != nil {
+		if found, findErr := s.exists(hubToolKey); findErr == nil && !found {
+			return nil
+		}
 		return err
 	}
 	if err := s.s.Erase(hubToolRefreshTokenKey); err != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/hub-tool/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed the "scary" message that was displayed when `hub-tool logout` when the user is already logged-out
closes #154 
  
**- How I did it**
When the erase of the hub-tool key from the store is failed I added a little check to make sure the key does not exists.

**- How to verify it**
Run `hub-tool logout` before `hub-tool login`.
You can also log out more than once as well.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed logout error when the user is already logged-out

**- A picture of a cute animal (not mandatory)**

