### PR TITLE
fix 2fa constant prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ ensure that its UX is good. Remember that this is an experiment with the goal of
 incorporating the learnings into the Docker CLI so it has some rough edges and
 it's not meant to be a final product.
 
+To get started wtih contributing, run `make help`. The commands that standout as
+helpful for new contributors are 
+
+```
+make lint      => make sure all files are formatted with 'go fmt'
+make test-unit => run unit tests
+make e2e       => run end-to-end tests
+make           => build it all for the local OS
+```
+
+For rapid iteration on running the project, use `go run main.go <args>`.
+Additional logging can be enabled by using the `--debug` or `--trace` flags.
+
+
 ### Feedback
 
 Please leave your feedback in the

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -59,6 +59,7 @@ func NewRootCmd(streams command.Streams, hubClient *hub.Client, store credential
 		DisableFlagsInUseLine: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if flags.trace {
+				log.Warn("Sensitive data can be logged when using the `--trace` flag")
 				log.SetLevel(log.TraceLevel)
 			} else if flags.verbose {
 				log.SetLevel(log.DebugLevel)
@@ -80,14 +81,8 @@ func NewRootCmd(streams command.Streams, hubClient *hub.Client, store credential
 Please login to Docker Hub using the "hub-tool login" command.`))
 			}
 
-			if cmd.Annotations["sudo"] == "true" {
-				if err := tryLogin(cmd.Context(), streams, hubClient, ac, store); err != nil {
-					return err
-				}
-				return nil
-			}
-
 			if ac.TokenExpired() {
+				log.Debugln("Token is expired, renewing")
 				return tryLogin(cmd.Context(), streams, hubClient, ac, store)
 			}
 			return nil

--- a/internal/hub/client.go
+++ b/internal/hub/client.go
@@ -218,6 +218,8 @@ func (c *Client) Login(username string, password string, twoFactorCodeProvider f
 		return "", "", err
 	}
 
+	log.Debugf("Login response %d on: %s", resp.StatusCode, resp.Request.URL)
+
 	// Login is OK, return the token
 	if resp.StatusCode == http.StatusOK {
 		creds := tokenResponse{}
@@ -264,6 +266,7 @@ func (c *Client) getTwoFactorToken(token string, twoFactorCodeProvider func() (s
 	if err != nil {
 		return "", "", err
 	}
+
 	resp, err := c.doRawRequest(req)
 	if err != nil {
 		return "", "", err
@@ -274,6 +277,10 @@ func (c *Client) getTwoFactorToken(token string, twoFactorCodeProvider func() (s
 	if err != nil {
 		return "", "", err
 	}
+
+	log.Debugf("Login response %d on: %s", resp.StatusCode, req.URL)
+	log.Tracef("HTTP response: %+v", resp)
+	log.Tracef("HTTP response body: %s", string(buf))
 
 	// Login is OK, return the token
 	if resp.StatusCode == http.StatusOK {
@@ -336,6 +343,9 @@ func (c *Client) doRawRequest(req *http.Request, reqOps ...RequestOp) (*http.Res
 	if c.Ctx != nil {
 		req = req.WithContext(c.Ctx)
 	}
+
+	log.Debugf("HTTP %s on: %s", req.Method, req.URL)
+	log.Tracef("HTTP request: %+v", req)
 	return http.DefaultClient.Do(req)
 }
 


### PR DESCRIPTION
**- What I did**
- added some documentation for newer contributors and additional logging
- remove forced reprompt of OTP, so that we only re-prompt when the token is expired.

Fixes #162, or at least makes it less painful.


A little bit of background... 

Upon first login using the `2fa-login` endpoint, a token is returned which gives the user full access to all Hub APIs. When refreshing the token, the resulting token has _reduced_ permissions, and so some APIs that initially worked with the first token will now fail. Until the Hub API is modified to allow refreshed tokens to have the same access as the first token, we need to do another prompt of the user's OTP to get another token which gives the tool full access to the Hub APIs.

**- How I did it**
- removed the code that logs in for every "sudo" command. 

**- How to verify it**

Below is output from some commands I ran and the date when they were run to show it working. 

Here is the first run with a token that is expired.
```
❯ date -u && go run main.go account info
Mon Feb  1 15:12:18 UTC 2021
2FA required, please provide the 6 digit code: XXXXXX
Name:           ahokanson
Full name:      Alex Hokanson
Company:        Docker, Inc
Location:
Joined:         17 months ago
Plan:           free
Limits:
  Seats:                1/1
  Private repositories: 1/1
  Teams:                unlimited
  Collaborators:        unlimited
  Parallel builds:      1
```

Then we run it again within the TTL of the token (30 minutes) and no reprompting of the OTP is required.
```
❯ date -u && go run main.go account info
Mon Feb  1 15:12:39 UTC 2021
Name:           ahokanson
Full name:      Alex Hokanson
Company:        Docker, Inc
Location:
Joined:         17 months ago
Plan:           free
Limits:
  Seats:                1/1
  Private repositories: 1/1
  Teams:                unlimited
  Collaborators:        unlimited
  Parallel builds:      1
```

One last run shows that the token has expired, again, and we are correctly prompted to provide the OTP for 2FA authentication
```
❯ date -u && go run main.go account info
Mon Feb  1 15:56:01 UTC 2021
2FA required, please provide the 6 digit code: XXXXXX
Name:           ahokanson
Full name:      Alex Hokanson
Company:        Docker, Inc
Location:
Joined:         17 months ago
Plan:           free
Limits:
  Seats:                1/1
  Private repositories: 1/1
  Teams:                unlimited
  Collaborators:        unlimited
  Parallel builds:      1
```

**- Description for the changelog**
- added some documentation for newer contributors and additional logging
- remove forced reprompt of OTP. 


**- A picture of a cute animal (not mandatory)**
<img width="495" alt="CleanShot 2021-02-01 at 11 13 23@2x" src="https://user-images.githubusercontent.com/571756/106485366-83832900-647e-11eb-9b5f-a44df45cf7c5.png">
