### PR TITLE
Fix org members and teams command output

### DIFF
--- a/internal/commands/org/members.go
+++ b/internal/commands/org/members.go
@@ -93,5 +93,5 @@ func printMembers(out io.Writer, values interface{}) error {
 		tw.Line()
 	}
 
-	return nil
+	return tw.Flush()
 }

--- a/internal/commands/org/teams.go
+++ b/internal/commands/org/teams.go
@@ -98,5 +98,5 @@ func printTeams(out io.Writer, values interface{}) error {
 		tw.Line()
 	}
 
-	return nil
+	return tw.Flush()
 }


### PR DESCRIPTION
**- What I did**
A flush was missing before exiting the command.

**- How to verify it**

```console
$ hub-tool org teams silvinorgtest
TEAM      DESCRIPTION                                        MEMBERS
owners    Full administrative access to the organization.    1
```

**- Description for the changelog**
* Fix org members and teams output

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/31478878/110922329-d7a3e780-831f-11eb-90c9-5c9616d3792d.png)

