### PR TITLE
add an AUTOMATED bool flag to help us know what repos need new ci/cd

### DIFF
--- a/internal/commands/repo/list.go
+++ b/internal/commands/repo/list.go
@@ -62,6 +62,10 @@ var (
 			s := fmt.Sprintf("%v", r.IsPrivate)
 			return s, len(s)
 		}},
+		{"AUTOMATED", func(r hub.Repository) (string, int) {
+			s := fmt.Sprintf("%v", r.IsAutomated)
+			return s, len(s)
+		}},
 	}
 )
 

--- a/internal/hub/repositories.go
+++ b/internal/hub/repositories.go
@@ -39,6 +39,7 @@ type Repository struct {
 	PullCount   int
 	StarCount   int
 	IsPrivate   bool
+	IsAutomated bool
 }
 
 //GetRepositories lists all the repositories a user can access
@@ -107,6 +108,7 @@ func (c *Client) getRepositoriesPage(url, account string) ([]Repository, int, st
 			PullCount:   result.PullCount,
 			StarCount:   result.StarCount,
 			IsPrivate:   result.IsPrivate,
+			IsAutomated: result.IsAutomated,
 		}
 		repos = append(repos, repo)
 	}


### PR DESCRIPTION
considering https://www.docker.com/blog/changes-to-docker-hub-autobuilds/, I wanted to see just how many repos I have to redo