### PR TITLE
introduce `org settings` command

### DIFF
--- a/internal/commands/org/cmd.go
+++ b/internal/commands/org/cmd.go
@@ -41,6 +41,7 @@ func NewOrgCmd(streams command.Streams, hubClient *hub.Client) *cobra.Command {
 		newListCmd(streams, hubClient, orgName),
 		newMembersCmd(streams, hubClient, orgName),
 		newTeamsCmd(streams, hubClient, orgName),
+		newSettingsCmd(streams, hubClient, orgName),
 	)
 	return cmd
 }

--- a/internal/commands/org/settings.go
+++ b/internal/commands/org/settings.go
@@ -1,0 +1,92 @@
+/*
+   Copyright 2020 Docker Hub Tool authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package org
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/cli/cli/utils"
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/hub-tool/internal/ansi"
+	"github.com/docker/hub-tool/internal/format"
+	"github.com/docker/hub-tool/internal/hub"
+	"github.com/docker/hub-tool/internal/metrics"
+	"github.com/spf13/cobra"
+)
+
+const (
+	settingsName = "settings"
+)
+
+type settingsOptions struct {
+	format.Option
+}
+
+func newSettingsCmd(streams command.Streams, hubClient *hub.Client, parent string) *cobra.Command {
+	var opts settingsOptions
+	cmd := &cobra.Command{
+		Use:                   settingsName + " ORGANIZATION",
+		Short:                 "Print the organization settings",
+		Args:                  cli.ExactArgs(1),
+		DisableFlagsInUseLine: true,
+		Annotations: map[string]string{
+			"sudo": "true",
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			metrics.Send(parent, settingsName)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOrgSettings(streams, hubClient, opts, args[0])
+		},
+	}
+	opts.AddFormatFlag(cmd.Flags())
+	return cmd
+}
+
+func runOrgSettings(streams command.Streams, hubClient *hub.Client, opts settingsOptions, orgName string) error {
+	settings, err := hubClient.GetOrganizationSettings(orgName)
+	if hub.IsForbiddenError(err) {
+		return fmt.Errorf(ansi.Error("failed to get organization settings, you need to be the organization Owner"))
+	}
+	if err != nil {
+		return err
+	}
+	return opts.Print(streams.Out(), *settings, printSettings)
+}
+
+func printSettings(out io.Writer, value interface{}) error {
+	settings := value.(hub.OrgSettings)
+
+	// print user info
+	fmt.Fprintf(out, ansi.Key("Restricted Images Access:               ")+"%s\n", enabled(settings.RestrictedImageAccessEnabled))
+	color := ansi.Key
+	if !settings.RestrictedImageAccessEnabled {
+		color = utils.Gray
+	}
+	fmt.Fprintf(out, color("Allow use of Official images:           ")+"%s\n", enabled(settings.OfficialImages))
+	fmt.Fprintf(out, color("Allow use of Verified Publisher images: ")+"%s\n", enabled(settings.VerifiedPublishers))
+	return nil
+}
+
+func enabled(settings bool) string {
+	if settings {
+		return ansi.Emphasise("Enabled")
+	}
+	return "Disabled"
+}

--- a/internal/commands/org/settings.go
+++ b/internal/commands/org/settings.go
@@ -74,13 +74,13 @@ func printSettings(out io.Writer, value interface{}) error {
 	settings := value.(hub.OrgSettings)
 
 	// print user info
-	fmt.Fprintf(out, ansi.Key("Restricted Images Access:               ")+"%s\n", enabled(settings.RestrictedImageAccessEnabled))
+	fmt.Fprintf(out, ansi.Key("Restricted Images Access:               ")+"%s\n", enabled(settings.RestrictedImages.Enabled))
 	color := ansi.Key
-	if !settings.RestrictedImageAccessEnabled {
+	if !settings.RestrictedImages.Enabled {
 		color = utils.Gray
 	}
-	fmt.Fprintf(out, color("Allow use of Official images:           ")+"%s\n", enabled(settings.OfficialImages))
-	fmt.Fprintf(out, color("Allow use of Verified Publisher images: ")+"%s\n", enabled(settings.VerifiedPublishers))
+	fmt.Fprintf(out, color("Allow use of Official images:           ")+"%s\n", enabled(settings.RestrictedImages.AllowOfficialImages))
+	fmt.Fprintf(out, color("Allow use of Verified Publisher images: ")+"%s\n", enabled(settings.RestrictedImages.AllowVerifiedPublishers))
 	return nil
 }
 

--- a/internal/hub/organizations.go
+++ b/internal/hub/organizations.go
@@ -123,9 +123,7 @@ func (c *Client) GetOrganizationSettings(orgname string) (*OrgSettings, error) {
 	}
 
 	return &OrgSettings{
-		RestrictedImageAccessEnabled: hubResponse.RestrictedImageAccessEnabled,
-		OfficialImages:               hubResponse.OfficialImages,
-		VerifiedPublishers:           hubResponse.VerifiedPublishers,
+		RestrictedImages: hubResponse.RestrictedImages,
 	}, nil
 }
 
@@ -234,7 +232,12 @@ type hubOrgInfoResponse struct {
 }
 
 type hubOrgSettingsResponse struct {
-	RestrictedImageAccessEnabled bool `json:"restrictedImageAccess"`
-	VerifiedPublishers           bool `json:"verifiedPublishers"`
-	OfficialImages               bool `json:"officialImages"`
+	RestrictedImages RestrictedImagesSettings `json:"restricted_images"`
+}
+
+// RestrictedImagesSettings define organization settings regarding Restricted Images Access
+type RestrictedImagesSettings struct {
+	Enabled                 bool `json:"enabled"`
+	AllowOfficialImages     bool `json:"allow_official_images"`
+	AllowVerifiedPublishers bool `json:"allow_verified_publishers"`
 }

--- a/internal/hub/user.go
+++ b/internal/hub/user.go
@@ -40,9 +40,7 @@ type Account struct {
 
 //OrgSettings represents settings for an organization
 type OrgSettings struct {
-	RestrictedImageAccessEnabled bool `json:"restrictedImageAccess"`
-	VerifiedPublishers           bool `json:"verifiedPublishers"`
-	OfficialImages               bool `json:"officialImages"`
+	RestrictedImages RestrictedImagesSettings
 }
 
 //GetUserInfo returns the information on the user retrieved from Hub

--- a/internal/hub/user.go
+++ b/internal/hub/user.go
@@ -38,6 +38,13 @@ type Account struct {
 	Joined   time.Time
 }
 
+//OrgSettings represents settings for an organization
+type OrgSettings struct {
+	RestrictedImageAccessEnabled bool `json:"restrictedImageAccess"`
+	VerifiedPublishers           bool `json:"verifiedPublishers"`
+	OfficialImages               bool `json:"officialImages"`
+}
+
 //GetUserInfo returns the information on the user retrieved from Hub
 func (c *Client) GetUserInfo() (*Account, error) {
 	u, err := url.Parse(c.domain + UserURL)


### PR DESCRIPTION
**- What I did**
Introduce `hub org settings <name>` command to list organization settings
(see https://github.com/docker/saas-mega/pull/6321)

When a top-level feature is disabled, sub-elements are displayer grayed but still show configured value:

![Capture d’écran du 2021-08-05 15-35-15](https://user-images.githubusercontent.com/132757/128359278-15463f02-2caa-4cff-9c50-3cda0edd3e5a.png)


**- How I did it**
new command

**- How to verify it**

**- Description for the changelog**
new command to list organization settings

**- A picture of a cute animal (not mandatory)**

