### PR TITLE
Add scope support to access tokens

### DIFF
--- a/internal/commands/token/list.go
+++ b/internal/commands/token/list.go
@@ -56,6 +56,12 @@ var (
 			s := fmt.Sprintf("%v", t.IsActive)
 			return s, len(s)
 		}},
+		{"SCOPE", func(t hub.Token) (string, int) {
+			if len(t.Scopes) == 0 {
+				return "", 0
+			}
+			return t.Scopes[0][5:], len(t.Scopes[0]) - 5
+		}},
 	}
 )
 

--- a/pkg/hub/tokens.go
+++ b/pkg/hub/tokens.go
@@ -46,11 +46,19 @@ type Token struct {
 	IsActive    bool
 	Token       string
 	Description string
+	Scopes      []string
 }
 
 // CreateToken creates a Personal Access Token and returns the token field only once
-func (c *Client) CreateToken(description string) (*Token, error) {
-	data, err := json.Marshal(hubTokenRequest{Description: description})
+func (c *Client) CreateToken(description string, scope string) (*Token, error) {
+	tokenRequest := hubTokenRequest{Description: description}
+	if len(scope) > 0 {
+		scopes := []string{scope}
+		scopes[0] = "repo:" + scope
+		tokenRequest.Scopes = scopes
+	}
+
+	data, err := json.Marshal(tokenRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -190,8 +198,9 @@ func (c *Client) getTokensPage(url string) ([]Token, int, string, error) {
 }
 
 type hubTokenRequest struct {
-	Description string `json:"token_label,omitempty"`
-	IsActive    bool   `json:"is_active"`
+	Description string   `json:"token_label,omitempty"`
+	Scopes      []string `json:"scopes,omitempty"`
+	IsActive    bool     `json:"is_active"`
 }
 
 type hubTokenResponse struct {
@@ -212,6 +221,7 @@ type hubTokenResult struct {
 	IsActive    bool      `json:"is_active"`
 	Token       string    `json:"token"`
 	TokenLabel  string    `json:"token_label"`
+	Scopes      []string  `json:"scopes"`
 }
 
 func convertToken(response hubTokenResult) (Token, error) {
@@ -230,5 +240,6 @@ func convertToken(response hubTokenResult) (Token, error) {
 		IsActive:    response.IsActive,
 		Token:       response.Token,
 		Description: response.TokenLabel,
+		Scopes:      response.Scopes,
 	}, nil
 }


### PR DESCRIPTION
**- What I did**

Add support for token scopes. Access Tokens created in the web interface can take a single scope value but this isn't available in `hub-tool`. This change lets the user create tokens with a specific scope.

**- How I did it**

Two user-facing changes:
1. Added a `--scope` parameter to `token create`. 
2. Added a SCOPE column to `token ls`

**- How to verify it**

The following calls add tokens with the specified scopes:
```
$ hub-tool token create --scope public_read --format json | jq -c '.Scopes'
[ "repo:public_read" ]
$ hub-tool token create --scope read --format json | jq -c '.Scopes'
[ "repo:read" ]
$ hub-tool token create --description test-cli-scope-5 --scope write --format json | jq -c '.Scopes'
[ "repo:write" ]
$ hub-tool token create --description test-cli-scope-5 --scope admin --format json | jq -c '.Scopes'
[ "repo:admin" ]
```

Showing the added column in `token ls`:
```
$ hub-tool token ls
DESCRIPTION         UUID                                    LAST USED         CREATED          ACTIVE    SCOPE
[...]
```

**- Description for the changelog**

Add scope support to access tokens

**- A picture of a cute animal (not mandatory)**

