### PR TITLE
Allow *http.Client to be replaced

### DIFF
--- a/pkg/hub/client.go
+++ b/pkg/hub/client.go
@@ -48,6 +48,7 @@ type Client struct {
 	AuthConfig types.AuthConfig
 	Ctx        context.Context
 
+	client           *http.Client
 	domain           string
 	token            string
 	refreshToken     string
@@ -86,6 +87,7 @@ func NewClient(ops ...ClientOp) (*Client, error) {
 	hubInstance := getInstance()
 
 	client := &Client{
+		client: http.DefaultClient,
 		domain: hubInstance.APIHubBaseURL,
 	}
 	for _, op := range ops {
@@ -167,6 +169,14 @@ func WithRefreshToken(refreshToken string) ClientOp {
 func WithPassword(password string) ClientOp {
 	return func(c *Client) error {
 		c.password = password
+		return nil
+	}
+}
+
+// WithHTTPClient sets the *http.Client for the client
+func WithHTTPClient(client *http.Client) ClientOp {
+	return func(c *Client) error {
+		c.client = client
 		return nil
 	}
 }
@@ -336,7 +346,7 @@ func (c *Client) doRawRequest(req *http.Request, reqOps ...RequestOp) (*http.Res
 	if c.Ctx != nil {
 		req = req.WithContext(c.Ctx)
 	}
-	return http.DefaultClient.Do(req)
+	return c.client.Do(req)
 }
 
 func extractError(buf []byte, resp *http.Response) (bool, error) {

--- a/pkg/hub/client_test.go
+++ b/pkg/hub/client_test.go
@@ -34,7 +34,8 @@ func TestDoRequestAddsCustomUserAgent(t *testing.T) {
 	defer server.Close()
 	req, err := http.NewRequest("GET", server.URL, nil)
 	assert.NilError(t, err)
-	client := Client{}
+	client, err := NewClient()
+	assert.NilError(t, err)
 	_, err = client.doRequest(req)
 	assert.NilError(t, err)
 }


### PR DESCRIPTION
**- What I did**
Currently [hub.Client](https://pkg.go.dev/github.com/docker/hub-tool@v0.4.3/pkg/hub#Client) uses [http.DefaultClient](https://pkg.go.dev/net/http#DefaultClient) to make requests. 
This change allows the [*http.Client](https://pkg.go.dev/net/http#Client) to be optionally replaced via a new [hub.ClientOp](https://pkg.go.dev/github.com/docker/hub-tool@v0.4.3/pkg/hub#ClientOp) (`WithHTTPClient`).

**- How I did it**
Moved the [*http.Client](https://pkg.go.dev/net/http#Client) instance into a un-exported `client` field of [hub.Client](https://pkg.go.dev/github.com/docker/hub-tool@v0.4.3/pkg/hub#Client).

**- How to verify it**
Implementation is very straightforward.

**- Description for the changelog**
Allow `*http.Client` to be replaced via `WithHTTPClient` function.

