### PR TITLE
Fix Login issue #191

### DIFF
--- a/pkg/hub/client.go
+++ b/pkg/hub/client.go
@@ -214,7 +214,7 @@ func (c *Client) Login(username string, password string, twoFactorCodeProvider f
 	body := bytes.NewBuffer(data)
 
 	// Login on the Docker Hub
-	req, err := http.NewRequest("POST", c.domain+LoginURL, ioutil.NopCloser(body))
+	req, err := http.NewRequest("POST", c.domain+LoginURL, body)
 	if err != nil {
 		return "", "", err
 	}
@@ -270,7 +270,7 @@ func (c *Client) getTwoFactorToken(token string, twoFactorCodeProvider func() (s
 	body := bytes.NewBuffer(data)
 
 	// Request 2FA on the Docker Hub
-	req, err := http.NewRequest("POST", c.domain+TwoFactorLoginURL, ioutil.NopCloser(body))
+	req, err := http.NewRequest("POST", c.domain+TwoFactorLoginURL, body)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
**- What I did**
Fix the login which failed with `Error: failed to authenticate: bad status code "400 Bad Request": malformed request: EOF`.

**- How I did it**

ioutil.NopCloser set content-length header to 0, which is no more accepted by the backend.

**- How to verify it**
```
$ hub-tool login
Username: slubecki
Password: 
2FA required, please provide the 6 digit code: XXXXXX
Login Succeeded
```

**- Description for the changelog**
Fix login issue #191 

**- A picture of a cute animal (not mandatory)**
![image](https://user-images.githubusercontent.com/31478878/142381777-895a7ca9-2550-412d-b5a4-fe372731ee48.png)

