### PR TITLE
Ignore 404 NOT FOUND when trying to delete a tag

### DIFF
--- a/internal/commands/tag/rm.go
+++ b/internal/commands/tag/rm.go
@@ -96,7 +96,12 @@ func runRm(ctx context.Context, streams command.Streams, hubClient *hub.Client, 
 	}
 
 	if err := hubClient.RemoveTag(reference.FamiliarName(ref), ref.Tag()); err != nil {
-		return err
+		if strings.Contains(err.Error(), "404 NOT FOUND") {
+			fmt.Fprintln(streams.Out(), "Not Found", image)
+			return nil
+		} else {
+			return err
+		}
 	}
 	fmt.Fprintln(streams.Out(), "Deleted", image)
 	return nil


### PR DESCRIPTION
Signed-off-by: Sean P. Kane <sean@superorbital.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/hub-tool/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added code to log, but otherwise ignore 404 NOT FOUND errors when deleting tags.

This addresses some additional functionality that was mentioned in:
https://github.com/docker/hub-tool/issues/58
 
**- How I did it**

Via a few lines of Go code

**- How to verify it**

Try and run a command like this twice against an existing image tag (or just run it against something that does not exist).

```sh
hub-tool tag rm -f myrepo/myimage:mytag
hub-tool tag rm -f myrepo/myimage:mytag
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

* Do not throw fatal errors when trying to delete a non-existent image tag.


**- A picture of a cute animal (not mandatory)**

![image](https://user-images.githubusercontent.com/129629/148441998-54c9c575-0b71-4125-862c-a90fa2d0c50f.png)
