### PR TITLE
Fixes #178

### DIFF
--- a/internal/commands/repo/rm.go
+++ b/internal/commands/repo/rm.go
@@ -47,7 +47,7 @@ type rmOptions struct {
 func newRmCmd(streams command.Streams, hubClient *hub.Client, parent string) *cobra.Command {
 	var opts rmOptions
 	cmd := &cobra.Command{
-		Use:                   rmName + " [OPTIONS] USERNAME/REPOSITORY",
+		Use:                   rmName + " [OPTIONS] REPOSITORY",
 		Short:                 "Delete a repository",
 		Args:                  cli.ExactArgs(1),
 		DisableFlagsInUseLine: true,

--- a/internal/commands/repo/rm.go
+++ b/internal/commands/repo/rm.go
@@ -47,7 +47,7 @@ type rmOptions struct {
 func newRmCmd(streams command.Streams, hubClient *hub.Client, parent string) *cobra.Command {
 	var opts rmOptions
 	cmd := &cobra.Command{
-		Use:                   rmName + " [OPTIONS] REPOSITORY",
+		Use:                   rmName + " [OPTIONS] USERNAME/REPOSITORY",
 		Short:                 "Delete a repository",
 		Args:                  cli.ExactArgs(1),
 		DisableFlagsInUseLine: true,
@@ -73,7 +73,7 @@ func runRm(ctx context.Context, streams command.Streams, hubClient *hub.Client, 
 	}
 	namedRef, ok := ref.(reference.Named)
 	if !ok {
-		return fmt.Errorf("invalid reference: repository not specified")
+		return errors.New("invalid reference: repository not specified")
 	}
 
 	if !opts.force {
@@ -104,6 +104,9 @@ func runRm(ctx context.Context, streams command.Streams, hubClient *hub.Client, 
 	if err := hubClient.RemoveRepository(namedRef.Name()); err != nil {
 		return err
 	}
-	fmt.Fprintln(streams.Out(), "Deleted", repository)
+	_, err = fmt.Fprintln(streams.Out(), fmt.Sprintf("Repository %q was deleted", repository))
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/commands/repo/rm.go
+++ b/internal/commands/repo/rm.go
@@ -47,7 +47,7 @@ type rmOptions struct {
 func newRmCmd(streams command.Streams, hubClient *hub.Client, parent string) *cobra.Command {
 	var opts rmOptions
 	cmd := &cobra.Command{
-		Use:                   rmName + " [OPTIONS] REPOSITORY",
+		Use:                   rmName + " [OPTIONS] USERNAME(OR)ORGANIZATION NAME/REPOSITORY",
 		Short:                 "Delete a repository",
 		Args:                  cli.ExactArgs(1),
 		DisableFlagsInUseLine: true,
@@ -74,6 +74,10 @@ func runRm(ctx context.Context, streams command.Streams, hubClient *hub.Client, 
 	namedRef, ok := ref.(reference.Named)
 	if !ok {
 		return errors.New("invalid reference: repository not specified")
+	}
+
+	if !strings.Contains(repository, "/") {
+		return fmt.Errorf("repository name must include username or organization name, example: hub-tool repo rm username/repository")
 	}
 
 	if !opts.force {
@@ -104,7 +108,7 @@ func runRm(ctx context.Context, streams command.Streams, hubClient *hub.Client, 
 	if err := hubClient.RemoveRepository(namedRef.Name()); err != nil {
 		return err
 	}
-	_, err = fmt.Fprintln(streams.Out(), fmt.Sprintf("Repository %q was deleted", repository))
+	_, err = fmt.Fprintf(streams.Out(), "Repository %q was successfully deleted\n", repository)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/repo/rm.go
+++ b/internal/commands/repo/rm.go
@@ -47,7 +47,7 @@ type rmOptions struct {
 func newRmCmd(streams command.Streams, hubClient *hub.Client, parent string) *cobra.Command {
 	var opts rmOptions
 	cmd := &cobra.Command{
-		Use:                   rmName + " [OPTIONS] USERNAME(OR)ORGANIZATION NAME/REPOSITORY",
+		Use:                   rmName + " [OPTIONS] NAMESPACE/REPOSITORY",
 		Short:                 "Delete a repository",
 		Args:                  cli.ExactArgs(1),
 		DisableFlagsInUseLine: true,

--- a/pkg/hub/client.go
+++ b/pkg/hub/client.go
@@ -309,6 +309,11 @@ func (c *Client) doRequest(req *http.Request, reqOps ...RequestOp) ([]byte, erro
 		defer resp.Body.Close() //nolint:errcheck
 	}
 	log.Tracef("HTTP response: %+v", resp)
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, &notFoundError{}
+	}
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if resp.StatusCode == http.StatusForbidden {
 			return nil, &forbiddenError{}

--- a/pkg/hub/error.go
+++ b/pkg/hub/error.go
@@ -56,3 +56,15 @@ func IsForbiddenError(err error) bool {
 	_, ok := err.(*forbiddenError)
 	return ok
 }
+
+type notFoundError struct{}
+
+func (n notFoundError) Error() string {
+	return "resource not found"
+}
+
+// IsNotFoundError check if the error type is a not found error
+func IsNotFoundError(err error) bool {
+	_, ok := err.(*notFoundError)
+	return ok
+}

--- a/pkg/hub/error_test.go
+++ b/pkg/hub/error_test.go
@@ -37,3 +37,8 @@ func TestIsForbiddenError(t *testing.T) {
 	assert.Assert(t, IsForbiddenError(&forbiddenError{}))
 	assert.Assert(t, !IsForbiddenError(errors.New("")))
 }
+
+func TestIsNotFoundError(t *testing.T) {
+	assert.Assert(t, IsNotFoundError(&notFoundError{}))
+	assert.Assert(t, !IsNotFoundError(errors.New("")))
+}

--- a/pkg/hub/repositories.go
+++ b/pkg/hub/repositories.go
@@ -25,10 +25,8 @@ import (
 )
 
 const (
-	// RepositoriesURL path to the Hub API listing the repositories
-	RepositoriesURL = "/v2/repositories/%s/"
-	// DeleteRepositoryURL path to the Hub API to remove a repository
-	DeleteRepositoryURL = "/v2/repositories/%s/"
+	// HubBaseURL is the Hub API base URL
+	HubBaseURL = "/v2/repositories/"
 )
 
 //Repository represents a Docker Hub repository
@@ -46,7 +44,9 @@ func (c *Client) GetRepositories(account string) ([]Repository, int, error) {
 	if account == "" {
 		account = c.account
 	}
-	u, err := url.Parse(c.domain + fmt.Sprintf(RepositoriesURL, account))
+	repositoriesURL := fmt.Sprintf("%s%s%s", c.domain, HubBaseURL, account)
+	fmt.Println(repositoriesURL)
+	u, err := url.Parse(repositoriesURL)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -75,14 +75,16 @@ func (c *Client) GetRepositories(account string) ([]Repository, int, error) {
 	return repos, total, nil
 }
 
-//RemoveRepository removes a repository on Hub
+//RemoveRepository receives repository parameter in the format ``username/repository``, and request repository deletion
+//on Hub using the user token
 func (c *Client) RemoveRepository(repository string) error {
-	req, err := http.NewRequest("DELETE", c.domain+fmt.Sprintf(DeleteRepositoryURL, repository), nil)
+	repositoryUrl := fmt.Sprintf("%s%s%s", c.domain, HubBaseURL, repository)
+	req, err := http.NewRequest(http.MethodDelete, repositoryUrl, nil)
 	if err != nil {
 		return err
 	}
 	_, err = c.doRequest(req, withHubToken(c.token))
-	return err
+	return nil
 }
 
 func (c *Client) getRepositoriesPage(url, account string) ([]Repository, int, string, error) {

--- a/pkg/hub/repositories.go
+++ b/pkg/hub/repositories.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	// HubBaseURL is the Hub API base URL
-	HubBaseURL = "/v2/repositories/"
+	// RepositoriesURL is the Hub API base URL
+	RepositoriesURL = "/v2/repositories/"
 )
 
 //Repository represents a Docker Hub repository
@@ -44,8 +44,7 @@ func (c *Client) GetRepositories(account string) ([]Repository, int, error) {
 	if account == "" {
 		account = c.account
 	}
-	repositoriesURL := fmt.Sprintf("%s%s%s", c.domain, HubBaseURL, account)
-	fmt.Println(repositoriesURL)
+	repositoriesURL := fmt.Sprintf("%s%s%s", c.domain, RepositoriesURL, account)
 	u, err := url.Parse(repositoriesURL)
 	if err != nil {
 		return nil, 0, err
@@ -75,15 +74,18 @@ func (c *Client) GetRepositories(account string) ([]Repository, int, error) {
 	return repos, total, nil
 }
 
-//RemoveRepository receives repository parameter in the format ``username/repository``, and request repository deletion
-//on Hub using the user token
+//RemoveRepository removes a repository on Hub
 func (c *Client) RemoveRepository(repository string) error {
-	repositoryUrl := fmt.Sprintf("%s%s%s", c.domain, HubBaseURL, repository)
+	repositoryUrl := fmt.Sprintf("%s%s%s/%s/", c.domain, RepositoriesURL, c.account, repository)
 	req, err := http.NewRequest(http.MethodDelete, repositoryUrl, nil)
 	if err != nil {
 		return err
 	}
 	_, err = c.doRequest(req, withHubToken(c.token))
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/hub/repositories.go
+++ b/pkg/hub/repositories.go
@@ -76,8 +76,8 @@ func (c *Client) GetRepositories(account string) ([]Repository, int, error) {
 
 //RemoveRepository removes a repository on Hub
 func (c *Client) RemoveRepository(repository string) error {
-	repositoryUrl := fmt.Sprintf("%s%s%s/%s/", c.domain, RepositoriesURL, c.account, repository)
-	req, err := http.NewRequest(http.MethodDelete, repositoryUrl, nil)
+	repositoryURL := fmt.Sprintf("%s%s%s/", c.domain, RepositoriesURL, repository)
+	req, err := http.NewRequest(http.MethodDelete, repositoryURL, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/hub-tool/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix one of the bugs reported by https://github.com/docker/hub-tool/issues/178 and improve error handling for the repository deletion. The repository cannot be deleted if Docker Hub username is not provided.

how to reproduce the issue:
```
# 1
hub-tool repo rm test
# 2
the output is a successful message because the HTTP response is not validated.
```

**- How I did it**

1. The fix includes the username to the repository deletion endpoint
2. Adds new error handler for HTTP Not Found
3. In case the repository doesn't exist, there is a proper error response: `Error: resource not found`
4. Improves the error message, making it clear which repository was deleted
5. Improve how URL is built before requesting the API

**- How to verify it**

The impacted changes can be tested via:

`./hub-tool repo rm repository-name`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Allow repository deletion by using repository name only (without username) and add error handler for resource/repository not found.

p.s: this PR doesn't fix one of the reported errors:

`Error: operation not permitted error`

Since this is an ongoing discussion: https://github.com/docker/hub-tool/issues/172

**- A picture of a cute animal (not mandatory)**

