### PR TITLE
Fix 186

### DIFF
--- a/internal/commands/token/list.go
+++ b/internal/commands/token/list.go
@@ -56,6 +56,12 @@ var (
 			s := fmt.Sprintf("%v", t.IsActive)
 			return s, len(s)
 		}},
+		{"SCOPE", func(t hub.Token) (string, int) {
+			if len(t.Scopes) == 0 {
+				return "", 0
+			}
+			return t.Scopes[0][5:], len(t.Scopes[0]) - 5
+		}},
 	}
 )
 

--- a/internal/commands/token/rm.go
+++ b/internal/commands/token/rm.go
@@ -67,11 +67,12 @@ func runRemove(streams command.Streams, hubClient *hub.Client, opts removeOption
 	}
 
 	if !opts.force {
-		fmt.Fprintf(streams.Out(), ansi.Warn("WARNING: This action is irreversible.")+`
-By confirming, you will permanently delete the access token.
-Deleting a token will invalidate your credentials on all Docker clients currently authenticated with this token.
 
-Please type your username %q to confirm deletion: `, hubClient.AuthConfig.Username)
+		fmt.Fprintf(streams.Out(), ansi.Warn("WARNING: This action is irreversible.")+`
+By confirming, you will permanently revoke and delete the access token.
+Revoking a token will invalidate your credentials on all Docker clients currently authenticated with this token.
+
+Please type your username %q to confirm token deletion: `, hubClient.AuthConfig.Username)
 		reader := bufio.NewReader(streams.In())
 		input, _ := reader.ReadString('\n')
 		input = strings.ToLower(strings.TrimSpace(input))
@@ -83,6 +84,6 @@ Please type your username %q to confirm deletion: `, hubClient.AuthConfig.Userna
 	if err := hubClient.RemoveToken(u.String()); err != nil {
 		return err
 	}
-	fmt.Fprintln(streams.Out(), ansi.Emphasise("Deleted"), u)
+	fmt.Fprintln(streams.Out(), ansi.Emphasise("Access token deleted"), u)
 	return nil
 }

--- a/pkg/hub/client.go
+++ b/pkg/hub/client.go
@@ -144,6 +144,7 @@ func WithOutStream(out io.Writer) ClientOp {
 // WithHubAccount sets the current account name
 func WithHubAccount(account string) ClientOp {
 	return func(c *Client) error {
+		c.AuthConfig.Username = account
 		c.account = account
 		return nil
 	}

--- a/pkg/hub/tokens.go
+++ b/pkg/hub/tokens.go
@@ -46,11 +46,19 @@ type Token struct {
 	IsActive    bool
 	Token       string
 	Description string
+	Scopes      []string
 }
 
 // CreateToken creates a Personal Access Token and returns the token field only once
-func (c *Client) CreateToken(description string) (*Token, error) {
-	data, err := json.Marshal(hubTokenRequest{Description: description})
+func (c *Client) CreateToken(description string, scope string) (*Token, error) {
+	tokenRequest := hubTokenRequest{Description: description}
+	if len(scope) > 0 {
+		scopes := []string{scope}
+		scopes[0] = "repo:" + scope
+		tokenRequest.Scopes = scopes
+	}
+
+	data, err := json.Marshal(tokenRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -190,8 +198,9 @@ func (c *Client) getTokensPage(url string) ([]Token, int, string, error) {
 }
 
 type hubTokenRequest struct {
-	Description string `json:"token_label,omitempty"`
-	IsActive    bool   `json:"is_active"`
+	Description string   `json:"token_label,omitempty"`
+	Scopes      []string `json:"scopes,omitempty"`
+	IsActive    bool     `json:"is_active"`
 }
 
 type hubTokenResponse struct {
@@ -212,6 +221,7 @@ type hubTokenResult struct {
 	IsActive    bool      `json:"is_active"`
 	Token       string    `json:"token"`
 	TokenLabel  string    `json:"token_label"`
+	Scopes      []string  `json:"scopes"`
 }
 
 func convertToken(response hubTokenResult) (Token, error) {
@@ -230,5 +240,6 @@ func convertToken(response hubTokenResult) (Token, error) {
 		IsActive:    response.IsActive,
 		Token:       response.Token,
 		Description: response.TokenLabel,
+		Scopes:      response.Scopes,
 	}, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/hub-tool/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

As reported on #186, user token deletion is failing to delete user access tokens. The issue is caused by the missing username at the `hubClient.AuthConfig.Username` struct field, the confirmation step looks for the username to confirm, but the username information is empty/not set.

**- How I did it**

At initialization, the `auth, err := store.GetAuth()` is called, I got it in advance, and provided the authorization data to the struct.

**- How to verify it**

1. create a new user token via `hub-tool token create`
2. delete the user token via `hub-tool token rm uuid-token`
3. the confirmation step will now show the username, and the username can be confirmed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix user token deletion by adding missing authorization data to the hubClient.


**- A picture of a cute animal (not mandatory)**

